### PR TITLE
fix(lib): operator precedence...

### DIFF
--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -30,7 +30,7 @@ in
     evalArgs:
     let
       res =
-        lib.evalModules {
+        lib.evalModules ({
           modules = [
             ./core.nix
           ]
@@ -52,7 +52,7 @@ in
         // (builtins.removeAttrs evalArgs [
           "modules"
           "specialArgs"
-        ]);
+        ]));
     in
     res;
 


### PR DESCRIPTION
Apparently only modules and specialArgs arguments worked before...

nix operator precedence can occasionally be hard.