### PR TITLE
feat(makeWrapper): flags option now allows per item override of separator

### DIFF
--- a/modules/makeWrapper/genArgsFromFlags.nix
+++ b/modules/makeWrapper/genArgsFromFlags.nix
@@ -1,0 +1,38 @@
+{ wlib, lib }:
+{
+  genArgs =
+    f: default-sep: dag:
+    wlib.dag.dagToDal (
+      builtins.mapAttrs (
+        n: v:
+        let
+          genArgs =
+            sep: name: value:
+            if lib.isList value then lib.concatMap (v: f true sep name v) value else f false sep name value;
+        in
+        v // { data = genArgs (if v.sep or null != null then v.sep else default-sep) n v.data; }
+      ) dag
+    );
+  flagDag =
+    with lib.types;
+    wlib.dag.dagWith
+      {
+        extraOptions = {
+          esc-fn = lib.mkOption {
+            type = lib.types.nullOr (lib.types.functionTo lib.types.str);
+            default = null;
+          };
+          sep = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+          };
+        };
+      }
+      (
+        nullOr (oneOf [
+          bool
+          wlib.types.stringable
+          (listOf wlib.types.stringable)
+        ])
+      );
+}

--- a/modules/makeWrapper/makeWrapper.nix
+++ b/modules/makeWrapper/makeWrapper.nix
@@ -5,46 +5,28 @@
   ...
 }:
 let
-  generateArgsFromFlags =
-    flagSeparator:
-    wlib.dag.mapDagToDal (
-      name: value:
-      if value == false || value == null then
-        [ ]
-      else if value == true then
-        [
-          "--add-flag"
-          name
-        ]
-      else if lib.isList value then
-        lib.concatMap (
-          v:
-          if lib.trim flagSeparator == "" then
-            [
-              "--add-flag"
-              name
-              "--add-flag"
-              (toString v)
-            ]
-          else
-            [
-              "--add-flag"
-              "${name}${flagSeparator}${toString v}"
-            ]
-        ) value
-      else if lib.trim flagSeparator == "" then
-        [
-          "--add-flag"
-          name
-          "--add-flag"
-          (toString value)
-        ]
-      else
-        [
-          "--add-flag"
-          "${name}${flagSeparator}${toString value}"
-        ]
-    );
+  generateArgsFromFlags = (import ./genArgsFromFlags.nix { inherit lib wlib; }).genArgs flaggenfunc;
+  flaggenfunc =
+    is_list: flagSeparator: name: value:
+    if !is_list && (value == false || value == null) then
+      [ ]
+    else if !is_list && value == true then
+      [
+        "--add-flag"
+        name
+      ]
+    else if lib.trim flagSeparator == "" && flagSeparator != "" then
+      [
+        "--add-flag"
+        name
+        "--add-flag"
+        (toString value)
+      ]
+    else
+      [
+        "--add-flag"
+        "${name}${flagSeparator}${toString value}"
+      ];
 
   argv0 = [
     (

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -215,15 +215,7 @@
     '';
   };
   options.flags = lib.mkOption {
-    type =
-      with lib.types;
-      wlib.types.dagWithEsc (
-        nullOr (oneOf [
-          bool
-          wlib.types.stringable
-          (listOf wlib.types.stringable)
-        ])
-      );
+    type = (import ./genArgsFromFlags.nix { inherit lib wlib; }).flagDag;
     default = { };
     example = {
       "--config" = "\${./nixPath}";
@@ -237,7 +229,9 @@
 
       This option takes a set.
 
-      Any entry can instead be of type `{ data, before ? [], after ? [], esc-fn ? null }`
+      Any entry can instead be of type `{ data, before ? [], after ? [], esc-fn ? null, sep ? null }`
+
+      The `sep` field may be used to override the value of `config.flagSeparator`
 
       This will cause it to be added to the DAG,
       which will cause the resulting wrapper argument to be sorted accordingly


### PR DESCRIPTION
flags dag entries accept a `sep` field alongside `esc-fn` and the normal dag entry fields