### PR TITLE
refactor(internal): __extend INTERNAL option is now more tamper-proof

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -402,7 +402,7 @@
             modules = (if builtins.isList module then module else [ module ]) ++ [
               {
                 _file = ./core.nix;
-                __extend = res.extendModules;
+                __extend = lib.mkOverride 0 res.extendModules;
               }
             ];
           };

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -31,7 +31,7 @@ in
           ++ [
             {
               _file = ./core.nix;
-              __extend = res.extendModules;
+              __extend = lib.mkOverride 0 res.extendModules;
             }
           ];
           specialArgs = {


### PR DESCRIPTION
set internal option with lib.mkOverride 0 so last ALWAYS wins