### PR TITLE
feat(symlinkScript): allow symlinkScript to return a function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,4 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Run checks
-        run: nix flake check --log-format bar-with-logs
+        run: nix flake check -Lv --log-format bar-with-logs


### PR DESCRIPTION
if it does this, it will receive the computed drv args, and then can have full control over the final set provided to mkDerivation.

This allows for extreme flexibility for advanced users

Also slightly improved the handling of sourceStdenv