### PR TITLE
refactor(escapeShellArgWithEnv): use lib.escape instead of builtins.replaceStrings

### DIFF
--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -193,9 +193,9 @@
 
     environment variable expansion (e.g., `$HOME`, `${VAR}`).
 
-    Caution! This is used by the `nix` backend for `wlib.modules.makeWrapper` to escape things,
-    but the `shell` and `binary` implementations pass their args to `pkgs.makeWrapper` at **build** time,
-    so it may not always do what you expect!
+    Caution! This is best used by the `nix` backend for `wlib.modules.makeWrapper` to escape things,
+    because the `shell` and `binary` implementations pass their args to `pkgs.makeWrapper` at **build** time,
+    so allowing variable expansion may not always do what you expect!
 
     # Example
 
@@ -215,13 +215,6 @@
 
     ```
   */
-  escapeShellArgWithEnv =
-    arg:
-    let
-      argStr = toString arg;
-      # Escape backslashes first, then double quotes
-      escaped = lib.replaceStrings [ ''\'' ''"'' ] [ ''\\'' ''\"'' ] argStr;
-    in
-    ''"${escaped}"'';
+  escapeShellArgWithEnv = arg: ''"${lib.escape [ ''\'' ''"'' ] (toString arg)}"'';
 
 }


### PR DESCRIPTION
mostly because it doesn't care what order you pass the things so its not as easily messed up later, but also it just feels like the right function to use.