### PR TITLE
feat(dagOf): wlib.types.dagOf is now as powerful as wlib.dag.dagWith

### DIFF
--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -185,8 +185,13 @@ in
 
     The `config.optionname` value from the associated option
     will be normalized such that all items are DAG entries
+
+    If you wish to alter the type, you may provide different options
+    to wlib.dag.dagWith by updating this type `wlib.dag.dagOf // { strict = false; }`
   */
-  dagOf = dagWith { };
+  dagOf = {
+    __functor = self: dagWith (builtins.removeAttrs self [ "__functor" ]);
+  };
 
   /**
     Arguments:
@@ -255,8 +260,13 @@ in
 
     The `config.optionname` value from the associated option
     will be normalized such that all items are DAG entries
+
+    If you wish to alter the type, you may provide different options
+    to wlib.dag.dalWith by updating this type `wlib.dag.dalOf // { strict = false; }`
   */
-  dalOf = dalWith { };
+  dalOf = {
+    __functor = self: dalWith (builtins.removeAttrs self [ "__functor" ]);
+  };
 
   /**
     Arguments:

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -49,7 +49,7 @@ in
 
     used by `wlib.modules.makeWrapper`
   */
-  dalWithEsc = wlib.dag.dalWith extradagopts;
+  dalWithEsc = wlib.types.dalOf // extradagopts;
 
   /**
     same as `dagOf` except with an extra field `esc-fn`
@@ -58,7 +58,7 @@ in
 
     used by `wlib.modules.makeWrapper`
   */
-  dagWithEsc = wlib.dag.dagWith extradagopts;
+  dagWithEsc = wlib.types.dagOf // extradagopts;
 
   /**
     Type for a value that can be converted to string `"${like_this}"`

--- a/modules/makeWrapper/genArgsFromFlags.nix
+++ b/modules/makeWrapper/genArgsFromFlags.nix
@@ -15,8 +15,9 @@
     );
   flagDag =
     with lib.types;
-    wlib.dag.dagWith
-      {
+    (
+      wlib.types.dagOf
+      // {
         extraOptions = {
           esc-fn = lib.mkOption {
             type = nullOr (functionTo str);
@@ -28,6 +29,7 @@
           };
         };
       }
+    )
       (
         nullOr (oneOf [
           bool


### PR DESCRIPTION
same for wlib.types.dalOf and wlib.dag.dalWith

you can `(wlib.dag.dagOf // { extraOptions = { ... }; ... }) elemType` to pass different args to the underlying function