### PR TITLE
feat(pkgs): modules now can recieve pkgs as an argument

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,14 @@ Example:
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 {
   imports = [ wlib.modules.default ];
   options = {
     "wezterm.lua" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.content = "return require('nix-info')";
       description = "The wezterm config file. provide `.content`, or `.path`";
     };
@@ -59,7 +60,7 @@ Example:
 
   config.flagSeparator = "=";
   config.flags = {
-    "--config-file" = config.pkgs.writeText "wezterm.lua" ''
+    "--config-file" = pkgs.writeText "wezterm.lua" ''
       local wezterm = require 'wezterm'
       package.preload["nix-info"] = function() return ${
         lib.generators.toLua { } config.luaInfo
@@ -68,7 +69,7 @@ Example:
     '';
   };
 
-  config.package = lib.mkDefault config.pkgs.wezterm;
+  config.package = lib.mkDefault pkgs.wezterm;
 
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/checks/apply.nix
+++ b/checks/apply.nix
@@ -7,9 +7,14 @@ let
   # Create a simple wrapper module
   helloModule =
     (self.lib.evalModule (
-      { config, wlib, ... }:
       {
-        config.package = config.pkgs.hello;
+        config,
+        wlib,
+        pkgs,
+        ...
+      }:
+      {
+        config.package = pkgs.hello;
         imports = [ wlib.modules.default ];
         config.flags = {
           "--greeting" = "initial";

--- a/checks/flags-module.nix
+++ b/checks/flags-module.nix
@@ -5,10 +5,15 @@
 
 let
   helloModule = self.lib.evalModule (
-    { config, wlib, ... }:
+    {
+      config,
+      wlib,
+      pkgs,
+      ...
+    }:
     {
       imports = [ wlib.modules.default ];
-      config.package = config.pkgs.hello;
+      config.package = pkgs.hello;
       config.flags = {
         "--greeting" = "world";
         "--silent" = true;

--- a/checks/meta-maintainers.nix
+++ b/checks/meta-maintainers.nix
@@ -8,9 +8,9 @@ let
   # { email = ...; github = ...; githubId = ...; keys = [ ... ]; name = ...; }
   nixpkgsMaintainer = pkgs.lib.maintainers.rycee;
   helloModule = self.lib.wrapModule (
-    { config, ... }:
+    { config, pkgs, ... }:
     {
-      config.package = config.pkgs.hello;
+      config.package = pkgs.hello;
       config.meta.maintainers = [ nixpkgsMaintainer ];
     }
   );

--- a/checks/meta-platforms.nix
+++ b/checks/meta-platforms.nix
@@ -6,9 +6,9 @@
 let
   # Test 1: Default platforms (should be lib.platforms.all)
   helloModuleDefault = self.lib.wrapModule (
-    { config, ... }:
+    { config, pkgs, ... }:
     {
-      config.package = config.pkgs.hello;
+      config.package = pkgs.hello;
     }
   );
 
@@ -16,9 +16,9 @@ let
 
   # Test 2: Custom platforms (linux only)
   helloModuleLinux = self.lib.wrapModule (
-    { config, ... }:
+    { config, pkgs, ... }:
     {
-      config.package = config.pkgs.hello;
+      config.package = pkgs.hello;
       config.meta.platforms = pkgs.lib.platforms.linux;
     }
   );
@@ -27,9 +27,9 @@ let
 
   # Test 3: Specific platforms list
   helloModuleSpecific = self.lib.wrapModule (
-    { config, ... }:
+    { config, pkgs, ... }:
     {
-      config.package = config.pkgs.hello;
+      config.package = pkgs.hello;
       config.meta.platforms = [
         "x86_64-linux"
         "aarch64-linux"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,9 +44,9 @@ They will get you started with a module file and the default one also gives you 
   in {
     packages = forAllSystems (system: {
       default = wrappers.wrapperModules.mpv.wrap (
-        {config, wlib, lib, ...}: {
+        {config, wlib, lib, pkgs, ...}: {
           pkgs = import nixpkgs { inherit system; };
-          scripts = [ config.pkgs.mpvScripts.mpris ];
+          scripts = [ pkgs.mpvScripts.mpris ];
           "mpv.conf".content = ''
             vo=gpu
             hwdec=auto
@@ -76,11 +76,11 @@ The package (via `passthru`) and the modules under `.config` both offer all 3 fu
 ```nix
 # Apply initial configuration
 # you can use `.eval` `.apply` or `.wrap` for this.
-initialConfig = (wrappers.wrapperModules.tmux.eval ({config, ...}{
+initialConfig = (wrappers.wrapperModules.tmux.eval ({config, pkgs, ...}{
   # but if you don't plan to provide pkgs yet, you can't use `.wrap` or `.wrapper` yet.
   # config.pkgs = pkgs;
-  # but we can still use `config.pkgs` before that inside!
-  config.plugins = [ config.pkgs.tmuxPlugins.onedark-theme ];
+  # but we can still use `pkgs` before that inside!
+  config.plugins = [ pkgs.tmuxPlugins.onedark-theme ];
   config.clock24 = false;
 })).config;
 
@@ -106,9 +106,9 @@ apackage = (actualPackage.eval {
 
 # and again! `.wrap` gives us back the package directly
 # all 3 forms take modules as an argument
-packageAgain = apackage.wrap ({config, ...}: {
+packageAgain = apackage.wrap ({config, pkgs, ...}: {
   # list definitions append when declared across modules by default!
-  plugins = [ config.pkgs.tmuxPlugins.fzf-tmux-url ];
+  plugins = [ pkgs.tmuxPlugins.fzf-tmux-url ];
 });
 ```
 
@@ -117,7 +117,7 @@ packageAgain = apackage.wrap ({config, ...}: {
 ```nix
 { wlib, lib }:
 
-(wlib.evalModule ({ config, wlib, lib, ... }: {
+(wlib.evalModule ({ config, wlib, lib, pkgs, ... }: {
   # You can only grab the final package if you supply pkgs!
   # But if you were making it for someone else, you would want them to do that!
 
@@ -137,7 +137,7 @@ packageAgain = apackage.wrap ({config, ...}: {
     };
   };
 
-  config.package = config.pkgs.ffmpeg;
+  config.package = pkgs.ffmpeg;
   config.flags = {
     "-preset" = if config.profile == "fast" then "veryfast" else "slow";
   };

--- a/lib/core.nix
+++ b/lib/core.nix
@@ -67,6 +67,7 @@ in
   config.drv = lib.mkIf (config.extraDrvAttrs != null) (
     lib.warn "extraDrvAttrs has been renamed to `config.drv`" config.extraDrvAttrs
   );
+  config._module.args.pkgs = config.pkgs;
   options = {
     meta = {
       maintainers = lib.mkOption {

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -93,7 +93,7 @@
           type = lib.types.str;
           default = "hello";
         };
-        config.package = config.pkgs.hello;
+        config.package = pkgs.hello;
         config.flags = {
           "--greeting" = config.greeting;
         };

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -2,6 +2,7 @@
   config,
   wlib,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -153,12 +154,12 @@
       [
         "LD_LIBRARY_PATH"
         ":"
-        "\${lib.makeLibraryPath (with config.pkgs; [ ... ])}"
+        "\${lib.makeLibraryPath (with pkgs; [ ... ])}"
       ]
       [
         "PATH"
         ":"
-        "\${lib.makeBinPath (with config.pkgs; [ ... ])}"
+        "\${lib.makeBinPath (with pkgs; [ ... ])}"
       ]
     ];
     description = ''
@@ -174,12 +175,12 @@
       [
         "LD_LIBRARY_PATH"
         ":"
-        "\${lib.makeLibraryPath (with config.pkgs; [ ... ])}"
+        "\${lib.makeLibraryPath (with pkgs; [ ... ])}"
       ]
       [
         "PATH"
         ":"
-        "\${lib.makeBinPath (with config.pkgs; [ ... ])}"
+        "\${lib.makeBinPath (with pkgs; [ ... ])}"
       ]
     ];
     description = ''
@@ -375,12 +376,7 @@
   config.drv.nativeBuildInputs =
     lib.mkIf (config.wrapperImplementation == "shell" || config.wrapperImplementation == "binary")
       [
-        (
-          if config.wrapperImplementation == "shell" then
-            config.pkgs.makeWrapper
-          else
-            config.pkgs.makeBinaryWrapper
-        )
+        (if config.wrapperImplementation == "shell" then pkgs.makeWrapper else pkgs.makeBinaryWrapper)
       ];
   config.wrapperFunction = lib.mkDefault (
     import (if config.wrapperImplementation == "nix" then ./makeWrapperNix.nix else ./makeWrapper.nix)

--- a/modules/symlinkScript/module.nix
+++ b/modules/symlinkScript/module.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 {
@@ -30,7 +31,7 @@
     };
   };
   config.drv.nativeBuildInputs = lib.mkIf ((config.filesToPatch or [ ]) != [ ]) [
-    config.pkgs.replace
+    pkgs.replace
   ];
   config.symlinkScript = lib.mkDefault (
     {

--- a/templates/flake/module.nix
+++ b/templates/flake/module.nix
@@ -2,6 +2,7 @@
   config,
   wlib,
   lib,
+  pkgs,
   ...
 }:
 {
@@ -11,7 +12,7 @@
     default = "hello";
     description = "The greeting to use";
   };
-  config.package = config.pkgs.hello;
+  config.package = pkgs.hello;
   config.flags = {
     "--greeting" = config.greeting;
   };

--- a/wrapperModules/a/alacritty/module.nix
+++ b/wrapperModules/a/alacritty/module.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 let
-  tomlFmt = config.pkgs.formats.toml { };
+  tomlFmt = pkgs.formats.toml { };
 in
 {
   imports = [ wlib.modules.default ];
@@ -22,6 +23,6 @@ in
   config.flags = {
     "--config-file" = tomlFmt.generate "alacritty.toml" config.settings;
   };
-  config.package = lib.mkDefault config.pkgs.alacritty;
+  config.package = lib.mkDefault pkgs.alacritty;
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/wrapperModules/f/foot/module.nix
+++ b/wrapperModules/f/foot/module.nix
@@ -2,10 +2,11 @@
   config,
   wlib,
   lib,
+  pkgs,
   ...
 }:
 let
-  iniFmt = config.pkgs.formats.ini { };
+  iniFmt = pkgs.formats.ini { };
 in
 {
   imports = [ wlib.modules.default ];
@@ -22,7 +23,7 @@ in
   config.flags = {
     "--config" = iniFmt.generate "foot.ini" config.settings;
   };
-  config.package = lib.mkDefault config.pkgs.foot;
+  config.package = lib.mkDefault pkgs.foot;
   config.meta.maintainers = [ wlib.maintainers.birdee ];
   config.meta.platforms = lib.platforms.linux;
 }

--- a/wrapperModules/f/fuzzel/module.nix
+++ b/wrapperModules/f/fuzzel/module.nix
@@ -2,10 +2,11 @@
   config,
   wlib,
   lib,
+  pkgs,
   ...
 }:
 let
-  iniFmt = config.pkgs.formats.ini { };
+  iniFmt = pkgs.formats.ini { };
 in
 {
   imports = [ wlib.modules.default ];
@@ -23,7 +24,7 @@ in
   config.flags = {
     "--config" = iniFmt.generate "fuzzel.ini" config.settings;
   };
-  config.package = lib.mkDefault config.pkgs.fuzzel;
+  config.package = lib.mkDefault pkgs.fuzzel;
   config.meta.maintainers = [ wlib.maintainers.birdee ];
   config.meta.platforms = lib.platforms.linux;
 }

--- a/wrapperModules/g/git/module.nix
+++ b/wrapperModules/g/git/module.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 let
-  gitIniFmt = config.pkgs.formats.gitIni { };
+  gitIniFmt = pkgs.formats.gitIni { };
 in
 {
   imports = [ wlib.modules.default ];
@@ -20,13 +21,13 @@ in
     };
 
     configFile = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.path = gitIniFmt.generate "gitconfig" config.settings;
       description = "Generated git configuration file.";
     };
   };
 
   config.env.GIT_CONFIG_GLOBAL = config.configFile.path;
-  config.package = lib.mkDefault config.pkgs.git;
+  config.package = lib.mkDefault pkgs.git;
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/wrapperModules/h/helix/module.nix
+++ b/wrapperModules/h/helix/module.nix
@@ -2,23 +2,24 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 let
-  tomlFmt = config.pkgs.formats.toml { };
+  tomlFmt = pkgs.formats.toml { };
   conf =
     let
       base = tomlFmt.generate "helix-config" config.settings;
     in
     if config.extraSettings != "" then
-      config.pkgs.concatText "helix-config" [
+      pkgs.concatText "helix-config" [
         base
-        (config.pkgs.writeText "extraSettings" config.extraSettings)
+        (pkgs.writeText "extraSettings" config.extraSettings)
       ]
     else
       base;
   langs = tomlFmt.generate "helix-languages-config" config.languages;
-  ignore = config.pkgs.writeText "helix-ignore" (lib.strings.concatLines config.ignores);
+  ignore = pkgs.writeText "helix-ignore" (lib.strings.concatLines config.ignores);
   themes = lib.mapAttrsToList (
     name: value:
     let
@@ -26,8 +27,7 @@ let
     in
     {
       name = "themes/${name}.toml";
-      path =
-        if lib.isString value then config.pkgs.writeText fname value else (tomlFmt.generate fname value);
+      path = if lib.isString value then pkgs.writeText fname value else (tomlFmt.generate fname value);
     }
   ) config.themes;
 in
@@ -80,10 +80,10 @@ in
       '';
     };
   };
-  config.package = lib.mkDefault config.pkgs.helix;
+  config.package = lib.mkDefault pkgs.helix;
   config.env = {
     XDG_CONFIG_HOME = builtins.toString (
-      config.pkgs.linkFarm "helix-merged-config" (
+      pkgs.linkFarm "helix-merged-config" (
         map
           (a: {
             inherit (a) path;

--- a/wrapperModules/j/jujutsu/module.nix
+++ b/wrapperModules/j/jujutsu/module.nix
@@ -2,10 +2,11 @@
   config,
   wlib,
   lib,
+  pkgs,
   ...
 }:
 let
-  tomlFmt = config.pkgs.formats.toml { };
+  tomlFmt = pkgs.formats.toml { };
 in
 {
   imports = [ wlib.modules.default ];
@@ -22,7 +23,7 @@ in
 
   config = {
     drv.dontFixup = true;
-    package = lib.mkDefault config.pkgs.jujutsu;
+    package = lib.mkDefault pkgs.jujutsu;
     env = {
       JJ_CONFIG = builtins.toString (tomlFmt.generate "jujutsu.toml" config.settings);
     };

--- a/wrapperModules/m/mako/module.nix
+++ b/wrapperModules/m/mako/module.nix
@@ -2,17 +2,18 @@
   config,
   wlib,
   lib,
+  pkgs,
   ...
 }:
 let
-  iniFormat = config.pkgs.formats.iniWithGlobalSection { };
+  iniFormat = pkgs.formats.iniWithGlobalSection { };
   iniAtomType = iniFormat.lib.types.atom;
 in
 {
   imports = [ wlib.modules.default ];
   options = {
     "--config" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.path = iniFormat.generate "mako-settings" { globalSection = config.settings; };
       description = ''
         Path to the generated Mako configuration file.
@@ -49,7 +50,7 @@ in
   # mako doesnt like fixupPhase
   config.drv.dontFixup = true;
 
-  config.package = lib.mkDefault config.pkgs.mako;
+  config.package = lib.mkDefault pkgs.mako;
 
   config.meta.maintainers = [ wlib.maintainers.birdee ];
   config.meta.platforms = lib.platforms.linux;

--- a/wrapperModules/m/mpv/module.nix
+++ b/wrapperModules/m/mpv/module.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 {
@@ -19,7 +20,7 @@
       '';
     };
     "mpv.input" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.content = "";
       description = ''
         The MPV input configuration file.
@@ -30,7 +31,7 @@
       '';
     };
     "mpv.conf" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.content = "";
       description = ''
         The main MPV configuration file.
@@ -47,7 +48,7 @@
     "--include" = config."mpv.conf".path;
   };
   config.package = lib.mkDefault (
-    config.pkgs.mpv.override {
+    pkgs.mpv.override {
       scripts = config.scripts;
     }
   );

--- a/wrapperModules/n/notmuch/module.nix
+++ b/wrapperModules/n/notmuch/module.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 let
-  iniFmt = config.pkgs.formats.ini { };
+  iniFmt = pkgs.formats.ini { };
   writeNotmuchConfig = cfg: iniFmt.generate "notmuch.ini" cfg;
 in
 {
@@ -34,7 +35,7 @@ in
       '';
     };
     configFile = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.path = toString (writeNotmuchConfig config.settings);
       description = ''
         Path or inline definition of the generated Notmuch configuration file.
@@ -44,7 +45,7 @@ in
       '';
     };
   };
-  config.package = config.pkgs.notmuch;
+  config.package = pkgs.notmuch;
   config.env.NOTMUCH_CONFIG = config.configFile.path;
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/wrapperModules/n/nushell/module.nix
+++ b/wrapperModules/n/nushell/module.nix
@@ -2,13 +2,14 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 {
   imports = [ wlib.modules.default ];
   options = {
     "env.nu" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.content = "";
       description = ''
         The Nushell environment configuration file.
@@ -19,7 +20,7 @@
       '';
     };
     "config.nu" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.content = "";
       description = ''
         The main Nushell configuration file.
@@ -37,7 +38,7 @@
     "--env-config" = config."env.nu".path;
   };
 
-  config.package = lib.mkDefault config.pkgs.nushell;
+  config.package = lib.mkDefault pkgs.nushell;
 
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/wrapperModules/r/rofi/module.nix
+++ b/wrapperModules/r/rofi/module.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 let
@@ -101,7 +102,7 @@ let
   theme =
     if (isAttrs config.theme) then
       builtins.toPath (
-        config.pkgs.writeTextFile {
+        pkgs.writeTextFile {
           name = "rofi-theme";
           text = toRasi config.theme;
         }
@@ -113,7 +114,7 @@ in
   imports = [ wlib.modules.default ];
   options = {
     "config.rasi" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.content =
         toRasi {
           configuration = config.settings;
@@ -172,7 +173,7 @@ in
   };
 
   config.package = lib.mkDefault (
-    config.pkgs.rofi.override (old: {
+    pkgs.rofi.override (old: {
       plugins = (old.plugins or [ ]) ++ config.plugins;
     })
   );

--- a/wrapperModules/t/tealdeer/module.nix
+++ b/wrapperModules/t/tealdeer/module.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 let
-  tomlFmt = config.pkgs.formats.toml { };
+  tomlFmt = pkgs.formats.toml { };
 in
 {
   imports = [ wlib.modules.default ];
@@ -22,6 +23,6 @@ in
   config.flags = {
     "--config-path" = tomlFmt.generate "tealdeer.toml" config.settings;
   };
-  config.package = lib.mkDefault config.pkgs.tealdeer;
+  config.package = lib.mkDefault pkgs.tealdeer;
   meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/wrapperModules/t/tmux/module.nix
+++ b/wrapperModules/t/tmux/module.nix
@@ -2,6 +2,7 @@
   config,
   wlib,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -228,13 +229,13 @@ in
   };
   config = {
     flags = {
-      "-f" = "${config.pkgs.writeText "tmux.conf" # tmux
+      "-f" = "${pkgs.writeText "tmux.conf" # tmux
         ''
           ${lib.optionalString config.sourceSensible ''
             # ============================================= #
             # Start with defaults from the Sensible plugin  #
             # --------------------------------------------- #
-            run-shell ${config.pkgs.tmuxPlugins.sensible.rtp}
+            run-shell ${pkgs.tmuxPlugins.sensible.rtp}
             # ============================================= #
           ''}
           unbind C-b
@@ -289,7 +290,7 @@ in
     runShell = lib.mkIf config.secureSocket [
       ''export TMUX_TMPDIR=''${TMUX_TMPDIR:-''${XDG_RUNTIME_DIR:-"/run/user/$(id -u)"}}''
     ];
-    package = config.pkgs.tmux;
+    package = pkgs.tmux;
     meta.maintainers = [ wlib.maintainers.birdee ];
   };
 }

--- a/wrapperModules/w/wezterm/module.nix
+++ b/wrapperModules/w/wezterm/module.nix
@@ -2,13 +2,14 @@
   config,
   lib,
   wlib,
+  pkgs,
   ...
 }:
 {
   imports = [ wlib.modules.default ];
   options = {
     "wezterm.lua" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
+      type = wlib.types.file pkgs;
       default.content = "return require('nix-info')";
       description = "The wezterm config file. provide `.content`, or `.path`";
     };
@@ -29,14 +30,14 @@
 
   config.flagSeparator = "=";
   config.flags = {
-    "--config-file" = config.pkgs.writeText "wezterm.lua" ''
+    "--config-file" = pkgs.writeText "wezterm.lua" ''
       local wezterm = require 'wezterm'
       package.preload["nix-info"] = function() return ${lib.generators.toLua { } config.luaInfo} end
       return dofile(${builtins.toJSON config."wezterm.lua".path})
     '';
   };
 
-  config.package = lib.mkDefault config.pkgs.wezterm;
+  config.package = lib.mkDefault pkgs.wezterm;
 
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }


### PR DESCRIPTION
it still needs to be provided to config.pkgs in all the same scenarios.

You can also still grab it via config.pkgs

but it gets added to config._module.args now so that you can grab it easier, in the normal arguments as if they were nixos or home manager modules.