### PR TITLE
feat(sourceables): more freedom over the way the wrapped package is l…

### DIFF
--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -7,10 +7,12 @@
 }:
 {
   options.argv0type = lib.mkOption {
-    type = lib.types.enum [
-      "resolve"
-      "inherit"
-    ];
+    type =
+      with lib.types;
+      either (enum [
+        "resolve"
+        "inherit"
+      ]) (functionTo str);
     default = "inherit";
     description = ''
       `argv0` overrides this option if not null or unset
@@ -29,10 +31,26 @@
       Use instead of `--argv0 '$0'`.
 
       `"resolve"`:
-
       `--resolve-argv0`
 
       If argv0 does not include a "/" character, resolve it against PATH.
+
+      # Function form:
+
+      This one works only in the nix implementation. The others will treat it as `inherit`
+
+      `argv0type = command_string: "eval \"$(''${command_string})\";`
+
+      Rather than calling exec, you get the command plus all its flags supplied,
+      and you can choose how to run it.
+
+      It will also be added to the end of the overall `DAL`,
+      with the name `NIX_RUN_MAIN_PACKAGE`
+
+      Thus, you can make things run after it,
+      but by default it is still last.
+
+      It also allows you to use `trap func EXIT` commands in a way which makes sense.
     '';
   };
   options.argv0 = lib.mkOption {


### PR DESCRIPTION
…aunched

in `nix` makeWrapper implementation

`argv0type = command: ''eval "$(${command})"'';`

Why? starship needs STARSHIP_CONFIG in the SHELL, not its own process

now you can `source ${wrappedstarship}/bin/starship` in a .zshrc

https://github.com/BirdeeHub/birdeeSystems/blob/0b4fe2d138faa5152d932fdc68756dfdcb7b4849/common/wrappers/starship/default.nix

https://github.com/BirdeeHub/birdeeSystems/blob/0b4fe2d138faa5152d932fdc68756dfdcb7b4849/common/wrappers/wezterm/zdot/default.nix#L46

https://github.com/BirdeeHub/birdeeSystems/blob/0b4fe2d138faa5152d932fdc68756dfdcb7b4849/common/modules/shell/fish.nix#L17