### PR TITLE
feat(sourceables): more freedom over the way the wrapped package is launched

### DIFF
--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -7,10 +7,12 @@
 }:
 {
   options.argv0type = lib.mkOption {
-    type = lib.types.enum [
-      "resolve"
-      "inherit"
-    ];
+    type =
+      with lib.types;
+      either (enum [
+        "resolve"
+        "inherit"
+      ]) (functionTo str);
     default = "inherit";
     description = ''
       `argv0` overrides this option if not null or unset
@@ -22,17 +24,29 @@
 
       Values:
 
-      `"inherit"`:
-      `--inherit-argv0`
+      - `"inherit"`:
 
       The executable inherits argv0 from the wrapper.
       Use instead of `--argv0 '$0'`.
 
-      `"resolve"`:
-
-      `--resolve-argv0`
+      - `"resolve"`:
 
       If argv0 does not include a "/" character, resolve it against PATH.
+
+      - Function form: `str -> str`
+
+      This one works only in the nix implementation. The others will treat it as `inherit`
+
+      Rather than calling exec, you get the command plus all its flags supplied,
+      and you can choose how to run it.
+
+      e.g. `command_string: "eval \"$(''${command_string})\";`
+
+      It will also be added to the end of the overall `DAL`,
+      with the name `NIX_RUN_MAIN_PACKAGE`
+
+      Thus, you can make things run after it,
+      but by default it is still last.
     '';
   };
   options.argv0 = lib.mkOption {


### PR DESCRIPTION
in `nix` makeWrapper implementation

`argv0type = command: ''eval "$(${command})"'';`

Why? starship needs STARSHIP_CONFIG in the SHELL, not its own process

now you can `source ${wrappedstarship}/bin/starship` in a .zshrc

Example useage

https://github.com/BirdeeHub/birdeeSystems/blob/a3c089ee035e5b12bcc65c040fec957a2e4b1ac6/common/wrappers/starship/default.nix

https://github.com/BirdeeHub/birdeeSystems/blob/a3c089ee035e5b12bcc65c040fec957a2e4b1ac6/common/wrappers/wezterm/zdot/default.nix#L46

https://github.com/BirdeeHub/birdeeSystems/blob/a3c089ee035e5b12bcc65c040fec957a2e4b1ac6/common/modules/shell/fish.nix#L17