### PR TITLE
hmmmm

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -113,7 +113,7 @@ in
       '';
     };
     passthru = lib.mkOption {
-      type = wlib.types.attrsRecursive;
+      type = wlib.types.recAttrs;
       default = { };
       description = ''
         Additional attributes to add to the resulting derivation's passthru.

--- a/wrapperModules/w/wezterm/module.nix
+++ b/wrapperModules/w/wezterm/module.nix
@@ -14,7 +14,7 @@
       description = "The wezterm config file. provide `.content`, or `.path`";
     };
     luaInfo = lib.mkOption {
-      type = wlib.types.attrsRecursive;
+      inherit (pkgs.formats.lua { }) type;
       default = { };
       description = ''
         anything other than uncalled nix functions can be put into this option, 


### PR DESCRIPTION
(removed, 1 min after pushing because it didn't solve the problem... my bad... I should wait longer)

You can still pass function-typed modules, you just have to declare them as a readOnly option. You can then grab them from passthru.configuration or from the evaluated config attribute from lib.evalModule