### PR TITLE
docs(collect): its over 9000

### DIFF
--- a/docs/collect.nix
+++ b/docs/collect.nix
@@ -24,7 +24,7 @@ let
           module
           {
             inherit pkgs;
-            package = lib.mkOrder 0 pkgs.hello;
+            package = lib.mkOverride 9001 pkgs.hello;
           }
         ];
       };
@@ -41,7 +41,7 @@ let
                 );
                 imports = [ mod ];
                 config.pkgs = pkgs;
-                config.package = lib.mkOrder 0 package;
+                config.package = lib.mkOverride 9001 package;
               }
             ];
           }).options
@@ -78,7 +78,7 @@ let
               builtins.removeAttrs
                 (wlib.evalModule {
                   inherit pkgs;
-                  package = lib.mkOrder 0 pkgs.hello;
+                  package = lib.mkOverride 9001 pkgs.hello;
                 }).options
                 [ "_module" ];
           };


### PR DESCRIPTION
apparently the docgen had mkOrder 0 when what it wanted was mkOverride 9001

It was working, but by accident.