### PR TITLE
fix(wrapperModules.xplr): iterate over returned hooks correctly

### DIFF
--- a/wrapperModules/x/xplr/check.nix
+++ b/wrapperModules/x/xplr/check.nix
@@ -40,6 +40,10 @@ let
     { lib, ... }:
     {
       inherit pkgs;
+      luaInit.testfile1 = {
+        before = [ "testfile" ];
+        data = "";
+      };
       luaInit.testfile = /* lua */ ''
         xplr.fn.custom.my_test = function()
           print("HELLO FROM HOOK")

--- a/wrapperModules/x/xplr/module.nix
+++ b/wrapperModules/x/xplr/module.nix
@@ -186,7 +186,8 @@ in
                  res)
 
                (var result {})
-               (each [_ h (ipairs hooks)]
+               (for [i 1 (select "#" ((or unpack table.unpack) hooks))]
+                 (local h (. hooks i))
                  (when (= (type h) :table) (set result (add-hooks result h))))
                result) [
                 ${generatedConfig}
@@ -211,7 +212,8 @@ in
                 return res
               end
               local result = {}
-              for _, h in ipairs(hooks) do
+              for i = 1, select('#', (unpack or table.unpack)(hooks)) do
+                local h = hooks[i]
                 if type(h) == "table" then
                   result = add_hooks(result, h)
                 end


### PR DESCRIPTION
select('#' in order to not have nils be the end of the list of hooks