### PR TITLE
feat(core): overrides option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ And you do not lose your ability to use `.override` or `.overrideAttrs` on the o
 
 The arguments will be passed through to the value of `config.package`,
 and the result will persist within the module system for future evaluations!
-(unless you explicitly override it with a new package)
 
 There are included modules for several programs already, but there are rich and easy to use options defined for creating your own modules as well!
 

--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -45,7 +45,6 @@ let
   inherit (wlib.dag)
     isEntry
     entryBetween
-    entryAnywhere
     entryAfter
     entriesBetween
     dagWith
@@ -135,16 +134,14 @@ let
           isEntry def.value && all (k: def.value ? ${k}) extrasWithoutDefaults
         else
           isEntry def.value
-          && all (k: elem k knownKeys && (extraOptions.${k}.type.check or (x: true)) def.value.${k}) (
-            attrNames def.value
-          )
+          && all (k: elem k knownKeys) (attrNames def.value)
           && all (k: def.value ? ${k}) extrasWithoutDefaults;
       maybeConvert =
         def:
         if checkMergeDef def then
           def.value
         else
-          entryAnywhere (if def ? priority then mkOrder def.priority def.value else def.value);
+          { data = if def ? priority then mkOrder def.priority def.value else def.value; };
     in
     mkOptionType {
       name = "dagEntryOf";
@@ -316,8 +313,8 @@ in
   isEntry =
     e:
     e ? data
-    && (if e ? after then isList e.after else true)
-    && (if e ? before then isList e.before else true)
+    && (if e ? after then isList e.after && all isString e.after else true)
+    && (if e ? before then isList e.before && all isString e.before else true)
     && (if e ? name then e.name == null || isString e.name else true);
 
   /**

--- a/modules/makeWrapper/makeWrapper.nix
+++ b/modules/makeWrapper/makeWrapper.nix
@@ -110,6 +110,7 @@ let
     (
       dag:
       wlib.dag.sortAndUnwrap {
+        name = "makeWrapper";
         inherit dag;
         mapIfOk =
           v:

--- a/modules/makeWrapper/makeWrapperNix.nix
+++ b/modules/makeWrapper/makeWrapperNix.nix
@@ -28,6 +28,7 @@ let
 
   preFlagStr = builtins.concatStringsSep " " (
     wlib.dag.sortAndUnwrap {
+      name = "addFlag";
       dag =
         lib.optionals (config.addFlag != [ ]) config.addFlag
         ++ lib.optionals (config.flags != { }) (
@@ -43,6 +44,7 @@ let
   );
   postFlagStr = builtins.concatStringsSep " " (
     wlib.dag.sortAndUnwrap {
+      name = "appendFlag";
       dag = config.appendFlag;
       mapIfOk =
         v:
@@ -114,6 +116,7 @@ let
 
   shellcmds = lib.optionals (shellcmdsdal != [ ] || lib.isFunction config.argv0type) (
     wlib.dag.sortAndUnwrap {
+      name = "makeWrapperNix";
       dag =
         shellcmdsdal
         ++ lib.optional (lib.isFunction config.argv0type) {

--- a/wrapperModules/m/mpv/check.nix
+++ b/wrapperModules/m/mpv/check.nix
@@ -7,6 +7,9 @@ let
   mpvWrapped =
     (self.wrapperModules.mpv.apply {
       inherit pkgs;
+      scripts = [
+        pkgs.mpvScripts.visualizer
+      ];
       "mpv.conf".content = ''
         ao=null
         vo=null
@@ -16,5 +19,6 @@ let
 in
 pkgs.runCommand "mpv-test" { } ''
   "${mpvWrapped}/bin/mpv" --version | grep -q "mpv"
+  cat "${mpvWrapped.configuration.package}/bin/mpv" | grep -q "share/mpv/scripts/visualizer.lua"
   touch $out
 ''

--- a/wrapperModules/m/mpv/module.nix
+++ b/wrapperModules/m/mpv/module.nix
@@ -47,10 +47,15 @@
     "--input-conf" = config."mpv.input".path;
     "--include" = config."mpv.conf".path;
   };
-  config.package = lib.mkDefault (
-    pkgs.mpv.override {
-      scripts = config.scripts;
+  config.overrides = [
+    {
+      name = "MPV_SCRIPTS";
+      type = "override";
+      data = prev: {
+        scripts = (prev.scripts or [ ]) ++ config.scripts;
+      };
     }
-  );
+  ];
+  config.package = lib.mkDefault pkgs.mpv;
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/wrapperModules/r/rofi/module.nix
+++ b/wrapperModules/r/rofi/module.nix
@@ -172,11 +172,16 @@ in
     "-config" = config."config.rasi".path;
   };
 
-  config.package = lib.mkDefault (
-    pkgs.rofi.override (old: {
-      plugins = (old.plugins or [ ]) ++ config.plugins;
-    })
-  );
+  config.package = lib.mkDefault pkgs.rofi;
+  config.overrides = [
+    {
+      name = "ROFI_PLUGINS";
+      type = "override";
+      data = prev: {
+        plugins = (prev.plugins or [ ]) ++ config.plugins;
+      };
+    }
+  ];
 
   config.meta.maintainers = [ wlib.maintainers.birdee ];
   config.meta.platforms = lib.platforms.linux;

--- a/wrapperModules/x/xplr/module.nix
+++ b/wrapperModules/x/xplr/module.nix
@@ -60,7 +60,12 @@ let
     if builtins.isString config.luaInit then
       config.luaInit
     else
-      builtins.filter (v: !v.disabled) (wlib.dag.sortAndUnwrap { dag = config.luaInit; });
+      builtins.filter (v: !v.disabled) (
+        wlib.dag.sortAndUnwrap {
+          name = "xplr_init";
+          dag = config.luaInit;
+        }
+      );
   hasFnl = builtins.any (v: v.type == "fnl") initDal;
   basePluginDir = "${placeholder "out"}/${config.binName}-plugins";
 in
@@ -248,6 +253,7 @@ in
         (
           dal:
           wlib.dag.sortAndUnwrap {
+            name = "xplr_plugins";
             dag = builtins.filter (v: !v.disabled) (wlib.dag.dagToDal config.plugins) ++ dal;
             mapIfOk = v: (mkLinkCommand v.name v.data);
           }


### PR DESCRIPTION
gave an organized method of adding overrides, so that people can change config.package without worrying about losing the overrides and/or any options which rely on the overrides.

converted mpv and rofi wrappers to use new method of calling override on the package

improved error messages for DAG extra fields

Add name field to sortAndUnwrap where used, for improved error messages