### PR TITLE
refactor(core): moved comment for internal option into description

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -488,9 +488,6 @@ in
         name = "lastWins";
         description = "All definitions (of the same priority) override the previous one";
         check = lib.isFunction;
-        # merge is ordered latest first within the same priority (of both types of priority)
-        # we always assign to this with lib.mkOverride 0 (lib.mkOrder 0 res.extendModules),
-        # this assures we can always override its value with the newest internal usage of this option.
         merge = loc: defs: (builtins.head defs).value;
         emptyValue = _: { };
       };
@@ -498,6 +495,12 @@ in
       description = ''
         Internal option storing the `.extendModules` function at each re-evaluation.
         Used by `.eval` to re-evaluate with additional modules.
+
+        We always assign to this with `lib.mkOverride 0 (lib.mkOrder 0 res.extendModules)`
+
+        merge is ordered latest first within the same priority (of both types of priority)
+
+        This assures we can always override its value with the newest internal usage of this option.
       '';
     };
     wrapper = lib.mkOption {


### PR DESCRIPTION
this option is the only internal one (meaning it doesnt show up in the docs)

The comment looked better here.