### PR TITLE
feat(lib.dag.dagWith): `extraOptions` no longer necessary

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -195,17 +195,19 @@ in
             (
               wlib.types.dalOf
               // {
-                extraOptions = {
-                  type = lib.mkOption {
-                    type = either (enum [
-                      "override"
-                      "overrideAttrs"
-                    ]) str;
-                    description = ''
-                      The attribute of `config.package` to pass the override argument to.
-                    '';
-                  };
-                };
+                modules = [
+                  {
+                    options.type = lib.mkOption {
+                      type = either (enum [
+                        "override"
+                        "overrideAttrs"
+                      ]) str;
+                      description = ''
+                        The attribute of `config.package` to pass the override argument to.
+                      '';
+                    };
+                  }
+                ];
               }
             )
               (either (attrsOf raw) (functionTo (attrsOf raw)));

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1,16 +1,20 @@
 { wlib, lib }:
 let
   extradagopts = {
-    extraOptions = {
-      esc-fn = lib.mkOption {
-        type = lib.types.nullOr (lib.types.functionTo lib.types.str);
-        default = null;
-      };
-    };
+    modules = [
+      {
+        options.esc-fn = lib.mkOption {
+          type = lib.types.nullOr (lib.types.functionTo lib.types.str);
+          default = null;
+        };
+      }
+    ];
   };
 in
 {
   /**
+    A DAG LIST or (DAL) or `dependency list` of some inner type
+
     Arguments:
     - `elemType`: `type`
 
@@ -22,11 +26,25 @@ in
 
     If a name is not given, it cannot be targeted by other values.
 
-    Can be used in conjunction with `wlib.dag.topoSort`
+    Can be used in conjunction with `wlib.dag.topoSort` and `wlib.dag.sortAndUnwrap`
+
+    Note, if the element type is a submodule then the `name` argument
+    will always be set to the string "data" since it picks up the
+    internal structure of the DAG values. To give access to the
+    "actual" attribute name a new submodule argument is provided with
+    the name `dagName`.
+
+    The `config.optionname` value from the associated option
+    will be normalized such that all items are DAG entries
+
+    If you wish to alter the type, you may provide different options
+    to `wlib.dag.dalWith` by updating this type `wlib.types.dalOf // { strict = false; }`
   */
   dalOf = wlib.dag.dalOf;
 
   /**
+    A directed acyclic graph of some inner type.
+
     Arguments:
     - `elemType`: `type`
 
@@ -38,8 +56,21 @@ in
 
     `name` defaults to the key in the set.
 
-    Can be used in conjunction with `wlib.dag.topoSort`
+    Can be used in conjunction with `wlib.dag.topoSort` and `wlib.dag.sortAndUnwrap`
+
+    Note, if the element type is a submodule then the `name` argument
+    will always be set to the string "data" since it picks up the
+    internal structure of the DAG values. To give access to the
+    "actual" attribute name a new submodule argument is provided with
+    the name `dagName`.
+
+    The `config.optionname` value from the associated option
+    will be normalized such that all items are DAG entries
+
+    If you wish to alter the type, you may provide different options
+    to `wlib.dag.dagWith` by updating this type `wlib.types.dagOf // { strict = false; }`
   */
+
   dagOf = wlib.dag.dagOf;
 
   /**

--- a/modules/makeWrapper/genArgsFromFlags.nix
+++ b/modules/makeWrapper/genArgsFromFlags.nix
@@ -18,12 +18,14 @@
     (
       wlib.types.dagOf
       // {
-        extraOptions = wlib.types.dagWithEsc.extraOptions // {
-          sep = lib.mkOption {
-            type = nullOr str;
-            default = null;
-          };
-        };
+        modules = wlib.types.dagWithEsc.modules ++ [
+          {
+            options.sep = lib.mkOption {
+              type = nullOr str;
+              default = null;
+            };
+          }
+        ];
       }
     )
       (

--- a/wrapperModules/x/xplr/module.nix
+++ b/wrapperModules/x/xplr/module.nix
@@ -12,6 +12,11 @@ let
       (
         { config, ... }:
         {
+          options.enable = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Enable the value";
+          };
           options.disabled = lib.mkOption {
             internal = true;
             type = lib.types.nullOr lib.types.bool;
@@ -27,38 +32,34 @@ let
         }
       )
     ];
-    extraOptions = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Enable the value";
-      };
-      disabled = true;
-    };
   };
   configDagOf = enabledDagOf // {
-    extraOptions = enabledDagOf.extraOptions // {
-      plugin = lib.mkOption {
-        type = lib.types.nullOr wlib.types.stringable;
-        default = null;
-        description = "You can add plugins to the config entries directly instead of `config.plugins`";
-      };
-      opts = lib.mkOption {
-        type = luaType;
-        default = { };
-        description = ''
-          Can be received in `.data` with `local opts, name = ...`
-        '';
-      };
-      type = lib.mkOption {
-        type = lib.types.enum [
-          "fnl"
-          "lua"
-        ];
-        default = config.defaultConfigLang;
-        description = "The language to be used within this config segment";
-      };
-    };
+    modules = enabledDagOf.modules ++ [
+      {
+        options = {
+          plugin = lib.mkOption {
+            type = lib.types.nullOr wlib.types.stringable;
+            default = null;
+            description = "You can add plugins to the config entries directly instead of `config.plugins`";
+          };
+          opts = lib.mkOption {
+            type = luaType;
+            default = { };
+            description = ''
+              Can be received in `.data` with `local opts, name = ...`
+            '';
+          };
+          type = lib.mkOption {
+            type = lib.types.enum [
+              "fnl"
+              "lua"
+            ];
+            default = config.defaultConfigLang;
+            description = "The language to be used within this config segment";
+          };
+        };
+      }
+    ];
   };
   initDal =
     if builtins.isString config.luaInit then


### PR DESCRIPTION
`extraOptions` no longer needed.

Simply add modules via the modules list passed to submoduleWith

The extra top level options added will be calculated and used to define the extra fields for the dag

`extraOptions` has been deprecated with a warning.