### PR TITLE
feat(lib.dag.dagWith): dal/dag v2 merge coherence

### DIFF
--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -170,15 +170,27 @@ let
       type = mkOptionType {
         name = "dagEntryOf";
         description = "DAG entry ${extraFieldsMsg}of ${elemType.description}";
-        # leave the checking to the submodule type
-        merge =
-          loc: defs:
-          submoduleType.merge loc (
-            map (def: {
-              inherit (def) file;
-              value = maybeConvert def;
-            }) defs
-          );
+        check = {
+          # leave the checking to the submodule type merge
+          __functor = _self: _x: true;
+          isV2MergeCoherent = true;
+        };
+        merge = {
+          __functor =
+            self: loc: defs:
+            (self.v2 { inherit loc defs; }).value;
+          v2 =
+            { loc, defs }:
+            submoduleType.merge.v2 {
+              inherit loc;
+              defs = (
+                map (def: {
+                  inherit (def) file;
+                  value = maybeConvert def;
+                }) defs
+              );
+            };
+        };
       };
     };
 in


### PR DESCRIPTION
If you don't know what this is, don't worry about it.

It makes extra things available in the `options` argument to modules (a `valueMeta` and `headError` field for the option)

It is optional to support, but now the dal and dag types support it, mirroring the values from the wrapped submodule type