### PR TITLE
fix(modules.makeWrapper): make all backends treat binName == "" the same

### DIFF
--- a/modules/makeWrapper/makeWrapperNix.nix
+++ b/modules/makeWrapper/makeWrapperNix.nix
@@ -137,11 +137,14 @@ let
     ++ lib.optional (config.prefixVar != [ ] || config.prefixContent != [ ]) prefixvarfunc
     ++ lib.optional (config.suffixVar != [ ] || config.suffixContent != [ ]) suffixvarfunc;
 in
-''
-  mkdir -p $out/bin
-  echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > $out/bin/${config.binName}
-  ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
-  ${builtins.concatStringsSep "\n" shellcmds}
-  ${lib.optionalString (!lib.isFunction config.argv0type) (wrapcmd "exec -a ${arg0} ${finalcmd}")}
-  chmod +x $out/bin/${config.binName}
-''
+if config.binName == "" then
+  ""
+else
+  ''
+    mkdir -p $out/bin
+    echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > $out/bin/${config.binName}
+    ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
+    ${builtins.concatStringsSep "\n" shellcmds}
+    ${lib.optionalString (!lib.isFunction config.argv0type) (wrapcmd "exec -a ${arg0} ${finalcmd}")}
+    chmod +x $out/bin/${config.binName}
+  ''


### PR DESCRIPTION
previously, when `config.binName` was an empty string the nix backend would throw and the others would do nothing.

now they all do nothing if `config.binName` is an empty string

the core options set explicitly calls `config.binName = ""` out as undefined behavior, but consistency is good.

By default the field is populated, you would have to specifically set it to an empty string to run into this anyway