### PR TITLE
fix(lib.dag.dagWith): in case submoduleWith stops accepting extra args

### DIFF
--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -118,6 +118,7 @@ let
           "modules"
           "extraOptions"
           "specialArgs"
+          "dontConvertFunctions"
           "shorthandOnlyDefinesConfig"
           "defaultNameFn"
           "dataTypeFn"


### PR DESCRIPTION
dont pass extra arguments to nixpkgs lib functions that they don't know about if you don't have to