### PR TITLE
feat(lib.types.subWrapperModuleWith): for making wrapper modules which take wrapper modules

### DIFF
--- a/checks/subwrappermodule.nix
+++ b/checks/subwrappermodule.nix
@@ -1,0 +1,46 @@
+{
+  pkgs,
+  self,
+}:
+let
+  eval'd = self.lib.wrapPackage [
+    { inherit pkgs; }
+    (
+      {
+        pkgs,
+        lib,
+        wlib,
+        config,
+        ...
+      }:
+      {
+        imports = [ wlib.modules.default ];
+        config.package = pkgs.bash;
+        options.subwrapped = lib.mkOption {
+          type = wlib.types.subWrapperModuleWith {
+            modules = [
+              {
+                imports = [ wlib.modules.default ];
+                config.pkgs = pkgs;
+                config.package = pkgs.hello;
+                config.flags."--greeting" = "test-phrase";
+              }
+            ];
+          };
+          default = { };
+        };
+        config.drv.dontFixup = true;
+        config.addFlag = [
+          [
+            "-c"
+            "${config.subwrapped.wrapper}/bin/${config.subwrapped.binName}"
+          ]
+        ];
+      }
+    )
+  ];
+in
+pkgs.runCommand "subwrappermodule-test" { } ''
+  ${pkgs.lib.getExe eval'd} | grep -q "test-phrase"
+  touch "$out"
+''


### PR DESCRIPTION
Maybe you are wrapping a window manager and you want to accept a status bar program and config for it as an option. Maybe you want to even expose custom options to that wrapper module when passed to your module.

`lib.types.submoduleWith` but with wrapper modules.

This type is also useable in nixos and home manager options, if you wanted to do that.