### PR TITLE
fix(lib.dag): improve error messages

### DIFF
--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -159,9 +159,9 @@ let
         if dontConvertFunctions && isFunction def.value then
           true
         else if !isStrict then
-          isEntry def.value && all (k: def.value ? ${k}) extrasWithoutDefaults
+          isAttrs def.value && all (k: def.value ? ${k}) extrasWithoutDefaults
         else
-          isEntry def.value
+          isAttrs def.value
           && all (k: elem k (attrNames subopts)) (attrNames def.value)
           && all (k: def.value ? ${k}) extrasWithoutDefaults;
       # converts if not already the submodule type


### PR DESCRIPTION
changed dag entry type-conversion logic slightly, such that it only cares about the top-level names passed and none of their types.

Before, if you messed up name, before, or after fields, it would convert the value and would give a confusing error message about the data field