### PR TITLE
fix(wrapperModules.tmux): default escape time 500 -> 10

### DIFF
--- a/wrapperModules/t/tmux/module.nix
+++ b/wrapperModules/t/tmux/module.nix
@@ -183,7 +183,7 @@ in
     };
     escapeTime = lib.mkOption {
       type = lib.types.int;
-      default = 500;
+      default = 10;
       description = "Value for `set -s escape-time`.";
     };
     historyLimit = lib.mkOption {


### PR DESCRIPTION
500 was too long. nvim checkhealth complains and it makes escape feel bad. Use what nvim checkhealth tells you to use by default.