### PR TITLE
fix(lib.types.subWrapperModuleWith): Also, feat(core): `config.extendModules`

### DIFF
--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -105,7 +105,7 @@ let
                     default = [ ];
                   };
                 };
-                config = mkIf (elemType.name == "submodule") {
+                config = mkIf (elemType.name == "submodule" || elemType.name == "subWrapperModule") {
                   data._module.args.dagName = config.name;
                 };
               }

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -36,7 +36,7 @@
           ++ [
             {
               _file = ./core.nix;
-              __extend = lib.mkOverride 0 (lib.mkOrder 0 res.extendModules);
+              extendModules = lib.mkOverride 0 (lib.mkOrder 0 res.extendModules);
             }
           ];
           specialArgs = {
@@ -53,7 +53,7 @@
         ])
       );
     in
-    res;
+    res // { inherit (res.config) extendModules; };
 
   /**
     `evalModule = module: wlib.evalModules { modules = if builtins.isList module then module else [ module ]; };`


### PR DESCRIPTION
fix(lib.types.subWrapperModuleWith):
while merge worked correctly, typeMerge did not, it would convert it back into a plain submodule type if you tried to define options for the subWrapperModule type across multiple files. Now it works correctly.

But also, new feature!

`config.extendModules`!

And also, you can call the regular `extendModules` now too, without having problems with losing any modules from previous evaluations.