### PR TITLE
fix(lib.types.subWrapperModuleWith): mkModuleAfter removed, config.extendModules.options added.

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -465,10 +465,20 @@ in
       default = module: extendModules { modules = lib.toList module; };
     };
     extendModules = lib.mkOption {
-      type = lib.types.functionTo lib.types.raw;
+      type = lib.types.raw // {
+        inherit (lib.types.functionTo lib.types.raw) description;
+      };
       readOnly = true;
-      default = extendModules;
-      description = "Alias for `.extendModules` so that you can call it from outside of `wlib.types.subWrapperModule` types";
+      default = args // {
+        __functionArgs = lib.functionArgs extendModules;
+        __functor = _: extendModules;
+      };
+      description = ''
+        Alias for `.extendModules` so that you can call it from outside of `wlib.types.subWrapperModule` types
+
+        In addition, it is also a set which stores the function args for the module evaluation.
+        This may prove useful when dealing with subWrapperModules or packages, which otherwise would not have access to some of them.
+      '';
     };
     wrapper = lib.mkOption {
       type = lib.types.package;


### PR DESCRIPTION
`mkModuleAfter` setting has been removed from `wlib.types.subWrapperModuleWith`

You may instead call `config.optionname.extendModules`, and use `config.optionname.extendModules.options` within it in order to achieve a similar result, but from outside the type itself.

If you wish it to happen automatically for an option, you may call it in the `apply` field for `lib.mkOption`

It was removed rather than deprecated because:

It existed for 2 days and was very likely never used.

It added a LOT of complexity to the type.

Adding the extra info to extendModules functor made it unnecessary.