### PR TITLE
feat(core): rename config.symlinkScript -> config.builderFunction

### DIFF
--- a/docs/core.md
+++ b/docs/core.md
@@ -8,7 +8,7 @@ They are always imported with every module evaluation.
 
 They are very minimal by design.
 
-The default `symlinkScript` value provides no options.
+The default `builderFunction` value provides no options.
 
 The default `wrapperFunction` is null.
 

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -16,11 +16,14 @@ in
     modules
     checks
     maintainers
+    modulesPath
     ;
 
   types = import ./types.nix { inherit lib wlib modulesPath; };
 
   dag = import ./dag.nix { inherit lib wlib; };
+
+  core = ./core.nix;
 
   /**
     calls `nixpkgs.lib.evalModules` with the core module imported and `wlib` added to `specialArgs`
@@ -33,7 +36,7 @@ in
       evalArgs
       // {
         modules = [
-          ./core.nix
+          wlib.core
         ]
         ++ (evalArgs.modules or [ ]);
         specialArgs = {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -108,6 +108,19 @@
   };
 
   /**
+    A single-line, non-empty string
+  */
+  nonEmptyline = lib.mkOptionType {
+    name = "nonEmptyline";
+    description = "non-empty line";
+    descriptionClass = "noun";
+    check =
+      x:
+      lib.types.str.check x && builtins.match "[ \t\n]*" x == null && builtins.match "[^\n\r]*" != null;
+    inherit (lib.types.str) merge;
+  };
+
+  /**
     Arguments:
     - `length`: `int`,
     - `elemType`: `type`
@@ -314,7 +327,7 @@
       base = lib.types.submoduleWith (
         args
         // {
-          modules = [ ./core.nix ] ++ modules;
+          modules = [ wlib.core ] ++ modules;
           specialArgs = {
             inherit modulesPath;
           }

--- a/modules/default/module.nix
+++ b/modules/default/module.nix
@@ -29,7 +29,7 @@
 
     ## `wlib.modules.symlinkScript`
 
-    Adds extra options compared to the default `symlinkScript` option value.
+    Adds extra options compared to the default `builderFunction` option value.
 
     ---
   '';

--- a/modules/symlinkScript/module.nix
+++ b/modules/symlinkScript/module.nix
@@ -33,7 +33,7 @@
   config.drv.nativeBuildInputs = lib.mkIf ((config.filesToPatch or [ ]) != [ ]) [
     pkgs.replace
   ];
-  config.symlinkScript = lib.mkDefault (
+  config.builderFunction = lib.mkDefault (
     {
       config,
       wlib,
@@ -139,7 +139,7 @@
   );
   config.meta.maintainers = lib.mkDefault [ wlib.maintainers.birdee ];
   config.meta.description = lib.mkDefault ''
-    Adds extra options compared to the default `symlinkScript` option value.
+    Adds extra options compared to the default `builderFunction` option value.
 
     Imported by `wlib.modules.default`
 


### PR DESCRIPTION
It gets control of the whole drv, symlinkScript was a weird name for it.

The other related option is `wrapperFunction` so `builderFunction` is a much better name.

also added a new way to use the new `config.builderFunction`

The type of `config.package` was made more lax to facilitate building of stuff in overrides or elsewhere.

binName and exePath can no longer be empty and will throw if they are.

config.outputs can no longer be empty, to match how derivations work.

added wlib.core and wlib.modulesPath for convenience