### PR TITLE
fix(flake): flake outputs wrapperModules -> wrappedModules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Merge main into PR branch
-        if: github.event_name == 'pull_request'
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git fetch origin main
-          if ! git merge origin/main; then
-            echo "Merge failed due to conflicts. Please rebase your branch on main."
-            exit 1
-          fi
+      # - name: Merge main into PR branch
+      #   if: github.event_name == 'pull_request'
+      #   run: |
+      #     git config user.name "GitHub Actions"
+      #     git config user.email "actions@github.com"
+      #     git fetch origin main
+      #     if ! git merge origin/main; then
+      #       echo "Merge failed due to conflicts. Please rebase your branch on main."
+      #       exit 1
+      #     fi
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -35,4 +35,4 @@ jobs:
       #   uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Run checks
-        run: nix flake check -Lv --log-format bar-with-logs
+        run: nix flake check -Lvv --log-format bar-with-logs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Example:
   self,
 }:
 let
-  gitWrapped = self.wrapperModules.git.wrap {
+  gitWrapped = self.wrappedModules.git.wrap {
     inherit pkgs;
     settings = {
       user = {

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ What if I told you, you can solve all those problems, and gain a really nice, co
 And it uses something you already know! The module system!
 
 ```nix
-inputs.nix-wrapper-modules.wrapperModules.alacritty.wrap {
+inputs.nix-wrapper-modules.wrappedModules.alacritty.wrap {
   inherit pkgs;
   settings.terminal.shell.program = "${pkgs.zsh}/bin/zsh";
   settings.terminal.shell.args = [ "-l" ];

--- a/docs/md/getting-started.md
+++ b/docs/md/getting-started.md
@@ -4,7 +4,8 @@ This library provides two main components:
 
 - `lib.evalModule`: Function to create reusable wrapper modules with type-safe configuration options
   - And related, `lib.wrapPackage`: an alias for `evalModule` which returns the package directly and pre-imports the `wlib.modules.default` module for convenience
-- `wrapperModules`: Pre-built wrapper modules for common packages (`tmux`, `wezterm`, etc.)
+- `wrapperModules`: Pre-made wrapper modules for common packages (`tmux`, `wezterm`, etc.)
+- `wrappedModules`: `wrapperModules` output, but partially evaluated for easier access to `.wrap` and other values in the module system.
 
 ## Usage
 
@@ -19,7 +20,7 @@ They will get you started with a module file and the default one also gives you 
   inputs.wrappers.url = "github:BirdeeHub/nix-wrapper-modules";
   outputs = { self, wrappers }: {
     packages.x86_64-linux.default =
-      wrappers.wrapperModules.wezterm.wrap ({ lib, ... }: {
+      wrappers.wrappedModules.wezterm.wrap ({ lib, ... }: {
         pkgs = wrappers.inputs.nixpkgs.legacyPackages.x86_64-linux;
         luaInfo = {
           keys = [
@@ -44,7 +45,7 @@ They will get you started with a module file and the default one also gives you 
     forAllSystems = with nixpkgs.lib; genAttrs platforms.all;
   in {
     packages = forAllSystems (system: {
-      default = wrappers.wrapperModules.mpv.wrap (
+      default = wrappers.wrappedModules.mpv.wrap (
         {config, wlib, lib, pkgs, ...}: {
           pkgs = import nixpkgs { inherit system; };
           scripts = [ pkgs.mpvScripts.mpris ];
@@ -77,7 +78,7 @@ The package (via `passthru`) and the modules under `.config` both offer all 3 fu
 ```nix
 # Apply initial configuration
 # you can use `.eval` `.apply` or `.wrap` for this.
-initialConfig = (wrappers.wrapperModules.tmux.eval ({config, pkgs, ...}{
+initialConfig = (wrappers.wrappedModules.tmux.eval ({config, pkgs, ...}{
   # but if you don't plan to provide pkgs yet, you can't use `.wrap` or `.wrapper` yet.
   # config.pkgs = pkgs;
   # but we can still use `pkgs` before that inside!

--- a/docs/md/wrapper-modules.md
+++ b/docs/md/wrapper-modules.md
@@ -10,6 +10,6 @@ They include shortlist options for common configuration settings, and/or for pro
 
 The flake also exports wrapper modules that have been partially evaluated for convenience.
 
-This allows you to do something like `inputs.nix-wrapper-modules.wrapperModules.tmux.wrap { inherit pkgs; prefix = "C-Space"; }`, to build a package with a particular configuration quickly!
+This allows you to do something like `inputs.nix-wrapper-modules.wrappedModules.tmux.wrap { inherit pkgs; prefix = "C-Space"; }`, to build a package with a particular configuration quickly!
 
 You can then export that package, and somebody else could call `.wrap` on it as well to change it again!

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,17 @@
     in
     {
       lib = import ./lib { inherit lib; };
-      wrapperModules = lib.mapAttrs (_: v: (self.lib.evalModule v).config) self.lib.wrapperModules;
+      wrappedModules = lib.mapAttrs (_: v: (self.lib.evalModule v).config) self.lib.wrapperModules;
+      wrapperModules = lib.mapAttrs (
+        _: v:
+        lib.warn ''
+          Attention: `wrapperModules` is deprecated, use `wrappedModules` instead
+
+          Apologies for any inconvenience this has caused. But the title `wrapperModules` should be specific to ones you can import.
+
+          In the future, rather than being removed, this will be replaced by the unevaluated wrapper modules from `wlib.wrapperModules`
+        '' (self.lib.evalModule v).config
+      ) self.lib.wrapperModules;
       formatter = forAllSystems (system: (fpkgs system).nixfmt-tree);
       templates = import ./templates;
       checks = forAllSystems (

--- a/templates/flake/flake.nix
+++ b/templates/flake/flake.nix
@@ -16,10 +16,11 @@
       wrapper = wrappers.lib.evalModule module;
     in
     {
-      overlays.default = final: prev: { hello = wrapper.config.wrap { pkgs = prev; }; };
-      wrapperModules = {
-        default = wrapper.config;
+      overlays.default = final: prev: {
+        ${wrapper.config.binName} = wrapper.config.wrap { pkgs = prev; };
       };
+      wrapperModules.default = module;
+      wrappedModules.default = wrapper.config;
       packages = forAllSystems (
         system:
         let

--- a/wrapperModules/g/git/check.nix
+++ b/wrapperModules/g/git/check.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  gitWrapped = self.wrapperModules.git.wrap {
+  gitWrapped = self.wrappedModules.git.wrap {
     inherit pkgs;
     settings = {
       user = {

--- a/wrapperModules/h/helix/check.nix
+++ b/wrapperModules/h/helix/check.nix
@@ -5,7 +5,7 @@
 
 let
   helixWrapped =
-    (self.wrapperModules.helix.apply {
+    (self.wrappedModules.helix.apply {
       inherit pkgs;
     }).wrapper;
 

--- a/wrapperModules/j/jujutsu/check.nix
+++ b/wrapperModules/j/jujutsu/check.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  jujutsuWrapped = self.wrapperModules.jujutsu.wrap {
+  jujutsuWrapped = self.wrappedModules.jujutsu.wrap {
     inherit pkgs;
     settings = {
       user = {

--- a/wrapperModules/m/mako/check.nix
+++ b/wrapperModules/m/mako/check.nix
@@ -5,13 +5,13 @@
 
 let
   makoWrapped =
-    (self.wrapperModules.mako.apply {
+    (self.wrappedModules.mako.apply {
       inherit pkgs;
       settings.icon-location = "left";
     }).wrapper;
 
 in
-if builtins.elem pkgs.stdenv.hostPlatform.system self.wrapperModules.mako.meta.platforms then
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.mako.meta.platforms then
   pkgs.runCommand "mako-test" { } ''
     "${makoWrapped}/bin/mako" --help | grep -q "mako"
     grep -q --no-ignore-case -- "--config" "${makoWrapped}/bin/mako"

--- a/wrapperModules/m/mpv/check.nix
+++ b/wrapperModules/m/mpv/check.nix
@@ -5,7 +5,7 @@
 
 let
   mpvWrapped =
-    (self.wrapperModules.mpv.apply {
+    (self.wrappedModules.mpv.apply {
       inherit pkgs;
       scripts = [
         pkgs.mpvScripts.visualizer

--- a/wrapperModules/n/notmuch/check.nix
+++ b/wrapperModules/n/notmuch/check.nix
@@ -5,7 +5,7 @@
 
 let
   notmuchWrapped =
-    (self.wrapperModules.notmuch.apply {
+    (self.wrappedModules.notmuch.apply {
       inherit pkgs;
       settings = {
         database.path = "/tmp/test-mail";

--- a/wrapperModules/n/nushell/check.nix
+++ b/wrapperModules/n/nushell/check.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  nushellWrapped = self.wrapperModules.nushell.wrap {
+  nushellWrapped = self.wrappedModules.nushell.wrap {
     inherit pkgs;
   };
 

--- a/wrapperModules/r/rofi/check.nix
+++ b/wrapperModules/r/rofi/check.nix
@@ -5,14 +5,14 @@
 
 let
   rofiWrapped =
-    (self.wrapperModules.rofi.apply {
+    (self.wrappedModules.rofi.apply {
       inherit pkgs;
 
       theme.foo = "bar";
     }).wrapper;
 
 in
-if builtins.elem pkgs.stdenv.hostPlatform.system self.wrapperModules.rofi.meta.platforms then
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.rofi.meta.platforms then
   pkgs.runCommand "rofi-test" { } ''
     # Rofi attempts to create some directories when first ran which doesn't work in a nix build
     export XDG_CACHE_HOME=/tmp

--- a/wrapperModules/w/wezterm/check.nix
+++ b/wrapperModules/w/wezterm/check.nix
@@ -3,7 +3,7 @@
   self,
 }:
 let
-  weztermWrapped = self.wrapperModules.wezterm.wrap (
+  weztermWrapped = self.wrappedModules.wezterm.wrap (
     { lib, ... }:
     {
       inherit pkgs;

--- a/wrapperModules/x/xplr/check.nix
+++ b/wrapperModules/x/xplr/check.nix
@@ -3,7 +3,7 @@
   self,
 }:
 let
-  xplr = self.wrapperModules.xplr.wrap (
+  xplr = self.wrappedModules.xplr.wrap (
     { lib, ... }:
     {
       inherit pkgs;
@@ -36,7 +36,7 @@ let
       };
     }
   );
-  xplr_linux_only_check = self.wrapperModules.xplr.wrap (
+  xplr_linux_only_check = self.wrappedModules.xplr.wrap (
     { lib, ... }:
     {
       inherit pkgs;


### PR DESCRIPTION
Yeah... My apologies for any inconvenience. Use mass find and replace.

The confusion between `wlib.wrapperModules` and flake `outputs.wrapperModules` and the not knowing what to export the importable ones as has to end.

`wrapperModules` vs `wrappedModules`

Guess which you can import and which you can't (you can't import the wrapped ones)

Much better.

In the future when the deprecation warning is removed, rather than removing the output, they will be replaced by the unevaluated wrapper modules, so that it has `outputs.wrapperModules` and `outputs.wrappedModules` outputs.