### PR TITLE
feat(lib.types.seriesOf): for `.override` and `.overrideAttrs` style behavior

### DIFF
--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -19,7 +19,7 @@ in
     modulesPath
     ;
 
-  types = import ./types.nix { inherit lib wlib modulesPath; };
+  types = import ./types.nix { inherit lib wlib; };
 
   dag = import ./dag.nix { inherit lib wlib; };
 
@@ -40,7 +40,7 @@ in
         ]
         ++ (evalArgs.modules or [ ]);
         specialArgs = {
-          inherit modulesPath;
+          inherit (wlib) modulesPath;
         }
         // (evalArgs.specialArgs or { })
         // {

--- a/modules/makeWrapper/genArgsFromFlags.nix
+++ b/modules/makeWrapper/genArgsFromFlags.nix
@@ -23,6 +23,9 @@
             options.sep = lib.mkOption {
               type = nullOr str;
               default = null;
+              description = ''
+                A per-item override of the default separator used for flags and their values
+              '';
             };
           }
         ];


### PR DESCRIPTION
Fully type-merge aware types

This is a big update. You can override the fields of DAG and DAL types, or construct your own ad-hoc ones! `wlib.dag.mkDagEntry` and `wlib.dag.dagNameModule` have been added for this purpose.

`wlib.types.seriesOf` was added, to fix type merging for `config.overrides`, and `config.overmods`, a prior workaround for the issue, has been deprecated with a descriptive warning about how to make it yourself.

`wlib.types.subWrapperModuleWith` is simply a submodule alias with more arguments