### PR TITLE
feat(lib.dag.unwrapSort): extra sort function, works better in pipes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,18 @@ pkgs.runCommand "git-test" { } ''
 ''
 ```
 
+If your module declares a list of valid platforms via its `meta.platforms` option, you should disable your test on the relevant platforms like so:
+
+```nix
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.waybar.meta.platforms then
+  pkgs.runCommand "waybar-test" { } ''
+    "${waybarWrapped}/bin/waybar" --version | grep -q "${waybarWrapped.version}"
+    touch $out
+  ''
+else
+  null
+```
+
 # Commit Messages
 
 Changes to wrapper modules should be titled `type(wrapperModules.<name>): some description`.

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -18,7 +18,7 @@ let
       # This gets you a list of each module, and those they import
       getGraph = import ./eval-graph.nix {
         inherit pkgs wlib;
-        rootPath = ../.;
+        rootPath = wlib.modulesPath;
       };
       corelist = builtins.attrNames (wlib.evalModule { }).options;
       graph = getGraph module;
@@ -93,8 +93,8 @@ let
           echo ${lib.escapeShellArg "  <summary></summary>"} >> $out
           echo >> $out
           cat ${doc.optionsCommonMark} | \
-            sed 's|file://${../.}|https://github.com/BirdeeHub/nix-wrapper-modules/blob/main|g' | \
-            sed 's|${../.}|https://github.com/BirdeeHub/nix-wrapper-modules/blob/main|g' >> $out
+            sed 's|file://${wlib.modulesPath}|https://github.com/BirdeeHub/nix-wrapper-modules/blob/main|g' | \
+            sed 's|${wlib.modulesPath}|https://github.com/BirdeeHub/nix-wrapper-modules/blob/main|g' >> $out
           echo >> $out
           echo ${lib.escapeShellArg "</details>"} >> $out
           echo >> $out
@@ -147,8 +147,8 @@ let
           echo ${lib.escapeShellArg desc.pre} > $out
           echo >> $out
           cat ${coreopts.optionsCommonMark} | \
-            sed 's|file://${../.}|https://github.com/BirdeeHub/nix-wrapper-modules/blob/main|g' | \
-            sed 's|${../.}|https://github.com/BirdeeHub/nix-wrapper-modules/blob/main|g' >> $out
+            sed 's|file://${wlib.modulesPath}|https://github.com/BirdeeHub/nix-wrapper-modules/blob/main|g' | \
+            sed 's|${wlib.modulesPath}|https://github.com/BirdeeHub/nix-wrapper-modules/blob/main|g' >> $out
           echo >> $out
           echo ${lib.escapeShellArg desc.post} >> $out
         ''

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,9 @@
               self = self;
             };
           };
-          checksFromModules = builtins.listToAttrs (lib.mapAttrsToList importModuleCheck self.lib.checks);
+          checksFromModules = builtins.listToAttrs (
+            builtins.filter (v: v.value or null != null) (lib.mapAttrsToList importModuleCheck self.lib.checks)
+          );
         in
         checksFromDir // checksFromModules
       );

--- a/lib/core.nix
+++ b/lib/core.nix
@@ -186,28 +186,20 @@ in
     package = lib.mkOption {
       apply =
         package:
-        builtins.foldl'
-          (
-            acc: v:
-            builtins.addErrorContext "config.overrides type error in ${acc} wrapper module!" (
-              if v.type == null then
-                builtins.addErrorContext "If `type` is `null`, then `data` must be a function!" (v.data acc)
-              else
-                builtins.addErrorContext "while calling: (${acc}).${v.type}:" (
-                  builtins.addErrorContext
-                    "If `type` is a string, then `config.package` must have that field, and it must be a function!"
-                    acc.${v.type}
-                    v.data
-                )
-            )
+        builtins.foldl' (
+          acc: v:
+          builtins.addErrorContext "config.overrides type error in ${acc} wrapper module!" (
+            if v.type == null then
+              builtins.addErrorContext "If `type` is `null`, then `data` must be a function!" (v.data acc)
+            else
+              builtins.addErrorContext "while calling: (${acc}).${v.type}:" (
+                builtins.addErrorContext
+                  "If `type` is a string, then `config.package` must have that field, and it must be a function!"
+                  acc.${v.type}
+                  v.data
+              )
           )
-          package
-          (
-            wlib.dag.sortAndUnwrap {
-              name = "overrides";
-              dag = config.overrides;
-            }
-          );
+        ) package (wlib.dag.unwrapSort "overrides" config.overrides);
       type = lib.types.addCheck wlib.types.stringable (
         v: if builtins.isString v then wlib.types.nonEmptyline.check v else true
       );

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -6,7 +6,7 @@
   wrapperModules ? wrappers_dir.wrapperModules or { },
   modules ? modules_dir.modules or { },
   maintainers ? import ../maintainers { inherit lib; },
-  modulesPath ? ../.,
+  modulesPath ? toString ../.,
   wlib ? import ./lib.nix {
     inherit
       lib

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -23,7 +23,7 @@ in
 
   dag = import ./dag.nix { inherit lib wlib; };
 
-  core = ./core.nix;
+  core = toString ./core.nix;
 
   /**
     calls `nixpkgs.lib.evalModules` with the core module imported and `wlib` added to `specialArgs`

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -130,7 +130,7 @@
 
     If a name is not given, it cannot be targeted by other values.
 
-    Can be used in conjunction with `wlib.dag.topoSort` and `wlib.dag.sortAndUnwrap`
+    Can be used in conjunction with `wlib.dag.topoSort`, `wlib.dag.sortAndUnwrap`, and `wlib.dag.unwrapSort`
 
     Note, if the element type is a submodule then the `name` argument
     will always be set to the string "data" since it picks up the
@@ -165,7 +165,7 @@
 
     `name` defaults to the key in the set.
 
-    Can be used in conjunction with `wlib.dag.topoSort` and `wlib.dag.sortAndUnwrap`
+    Can be used in conjunction with `wlib.dag.topoSort`, `wlib.dag.sortAndUnwrap`, and `wlib.dag.unwrapSort`
 
     Note, if the element type is a submodule then the `name` argument
     will always be set to the string "data" since it picks up the

--- a/modules/makeWrapper/makeWrapper.nix
+++ b/modules/makeWrapper/makeWrapper.nix
@@ -107,19 +107,14 @@ let
     "${placeholder "out"}/bin/${config.binName}"
   ];
   resArgs = lib.pipe finalArgs [
-    (
-      dag:
-      wlib.dag.sortAndUnwrap {
-        name = "makeWrapper";
-        inherit dag;
-        mapIfOk =
-          v:
-          let
-            esc-fn = if v.esc-fn or null != null then v.esc-fn else config.escapingFunction;
-          in
-          if builtins.isList v.data then map esc-fn v.data else esc-fn v.data;
-      }
-    )
+    (wlib.dag.unwrapSort "makeWrapper")
+    (map (
+      v:
+      let
+        esc-fn = if v.esc-fn or null != null then v.esc-fn else config.escapingFunction;
+      in
+      if builtins.isList v.data then map esc-fn v.data else esc-fn v.data
+    ))
     lib.flatten
   ];
 in

--- a/wrapperModules/m/mako/check.nix
+++ b/wrapperModules/m/mako/check.nix
@@ -18,6 +18,4 @@ if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.mako.meta.p
     touch $out
   ''
 else
-  pkgs.runCommand "mako-test-disabled" { } ''
-    touch $out
-  ''
+  null

--- a/wrapperModules/r/rofi/check.nix
+++ b/wrapperModules/r/rofi/check.nix
@@ -35,4 +35,4 @@ if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.rofi.meta.p
     touch $out
   ''
 else
-  pkgs.runCommand "rofi-test-disabled" { } "touch $out"
+  null

--- a/wrapperModules/w/waybar/check.nix
+++ b/wrapperModules/w/waybar/check.nix
@@ -17,12 +17,10 @@ let
   };
 
 in
-if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.mako.meta.platforms then
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.waybar.meta.platforms then
   pkgs.runCommand "waybar-test" { } ''
     "${waybarWrapped}/bin/waybar" --version | grep -q "${waybarWrapped.version}"
     touch $out
   ''
 else
-  pkgs.runCommand "waybar-test-disabled" { } ''
-    touch $out
-  ''
+  null

--- a/wrapperModules/x/xplr/module.nix
+++ b/wrapperModules/x/xplr/module.nix
@@ -65,12 +65,7 @@ let
     if builtins.isString config.luaInit then
       config.luaInit
     else
-      builtins.filter (v: v.enable) (
-        wlib.dag.sortAndUnwrap {
-          name = "xplr_init";
-          dag = config.luaInit;
-        }
-      );
+      builtins.filter (v: v.enable) (wlib.dag.unwrapSort "xplr_init" config.luaInit);
   hasFnl = builtins.any (v: v.type == "fnl") initDal;
   basePluginDir = "${placeholder "out"}/${config.binName}-plugins";
 in
@@ -255,14 +250,9 @@ in
         (v: if builtins.isString v then [ ] else v)
         (map (v: if v.plugin or null != null then v // { data = v.plugin; } else null))
         (builtins.filter (v: v != null))
-        (
-          dal:
-          wlib.dag.sortAndUnwrap {
-            name = "xplr_plugins";
-            dag = builtins.filter (v: v.enable) (wlib.dag.dagToDal config.plugins) ++ dal;
-            mapIfOk = v: (mkLinkCommand v.name v.data);
-          }
-        )
+        (dal: builtins.filter (v: v.enable) (wlib.dag.dagToDal config.plugins) ++ dal)
+        (wlib.dag.unwrapSort "xplr_plugins")
+        (map (v: mkLinkCommand v.name v.data))
         (builtins.concatStringsSep "\n")
       ];
     in


### PR DESCRIPTION
The other one didn't pipe well, but it is still sometimes nicer. No harm in having both in this case, so I added it and used it in a few places.

Also added the ability for modules within the repo to return null from their check.nix file instead of a derivation in order to not run.