### PR TITLE
feat(wrapperModules.openssh): init

### DIFF
--- a/wrapperModules/o/openssh/check.nix
+++ b/wrapperModules/o/openssh/check.nix
@@ -1,0 +1,27 @@
+{
+  pkgs,
+  self,
+}:
+let
+  opensshWrapped = self.wrappedModules.openssh.wrap {
+    inherit pkgs;
+
+    settings = ''
+      Host foo
+        User bar
+        HostName 192.168.0.2
+        ProxyJump baz
+
+      Host baz
+        HostName 192.168.0.1
+    '';
+  };
+
+in
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.openssh.meta.platforms then
+  pkgs.runCommand "ssh-test" { } ''
+    "${opensshWrapped}/bin/ssh" -G foo | grep -q 'HostName 192.168.0.2'
+    touch $out
+  ''
+else
+  null

--- a/wrapperModules/o/openssh/module.nix
+++ b/wrapperModules/o/openssh/module.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  wlib,
+  lib,
+  ...
+}:
+{
+  imports = [ wlib.modules.default ];
+
+  options = {
+    settings = lib.mkOption {
+      type = lib.types.string;
+      default = "";
+      description = ''
+        OpenSSH client configuration settings.
+        See `man 5 ssh_config`
+      '';
+      example = ''
+        Host foo
+          User bar
+          HostName 192.168.0.2
+          ProxyJump baz
+
+        Host baz
+          HostName 192.168.0.1
+      '';
+    };
+  };
+
+  config = {
+    package = lib.mkDefault config.pkgs.openssh;
+    flags = {
+      "-F" = builtins.toString (config.pkgs.writeText "ssh-config" config.settings);
+    };
+    meta = {
+      inherit (config.package) platforms;
+      maintainers = [ wlib.maintainers.patwid ];
+    };
+  };
+}


### PR DESCRIPTION
Add openssh wrapper module (allowing for project specific ssh client configuration).

Currently, completely unstructured. Later it we could switch to a structured configuration (maybe analogous to home-manager). Also I don't know how to test the module, yet.