### PR TITLE
fix(modules.makeWrapper): used wrong type of subshell in latest update

### DIFF
--- a/modules/makeWrapper/makeWrapper.nix
+++ b/modules/makeWrapper/makeWrapper.nix
@@ -127,7 +127,7 @@ if config.binName == "" then
   ""
 else
   ''
-    $(
+    (
       ${srcsetup dieHook}
       ${srcsetup (if config.wrapperImplementation == "shell" then makeWrapper else makeBinaryWrapper)}
       makeWrapper ${baseArgs} ${builtins.concatStringsSep " " resArgs}


### PR DESCRIPTION
It worked, just not in the way I was expecting.