### PR TITLE
fix(wrapperModules.claude-code): broken mcpConfig

### DIFF
--- a/wrapperModules/c/claude-code/check.nix
+++ b/wrapperModules/c/claude-code/check.nix
@@ -16,6 +16,11 @@ let
   };
 in
 pkgs.runCommand "claude-code-test" { } ''
-  "${claudeCodeWrapped}/bin/claude" mcp get nixos
+  claude="${claudeCodeWrapped}/bin/claude"
+  if ! grep -q -- "--strict-mcp-config" "$claude"; then
+    echo "FAIL: --strict-mcp-config flag not found in wrapped claude binary"
+    cat "$claude"
+    exit 1
+  fi
   touch $out
 ''

--- a/wrapperModules/c/claude-code/module.nix
+++ b/wrapperModules/c/claude-code/module.nix
@@ -81,7 +81,8 @@ in
       DISABLE_INSTALLATION_CHECKS = "1";
     };
     flags = {
-      "--mcp-config" = jsonFmt.generate "claude-mcp-config.json" { mcpServers = config.settings; };
+
+      "--mcp-config" = jsonFmt.generate "claude-mcp-config.json" { mcpServers = config.mcpConfig; };
       "--strict-mcp-config" = config.strictMcpConfig;
       "--settings" = jsonFmt.generate "claude-settings.json" config.settings;
     };


### PR DESCRIPTION
1. The `--mcp-config` flag was incorrectly using `config.settings` instead of `config.mcpConfig`
2. It turns out the previous test wasn't actually doing was it appeared to. The MCP config was invalid (since it was using settings), and it just ? does nothing ? in that case instead of erroring out. Additionally, it turns out the `claude mcp get <server>` command doesn't respect the CLI flags at all, so the test was never actually going to work.

(i was way too tired last night apologies again)