### PR TITLE
fix(wrapperModules.neovim): default value

### DIFF
--- a/wrapperModules/n/neovim/module.nix
+++ b/wrapperModules/n/neovim/module.nix
@@ -448,8 +448,8 @@ in
                   '';
                 };
                 config = lib.mkOption {
-                  type = types.lines;
-                  default = "";
+                  type = types.nullOr types.lines;
+                  default = null;
                   description = ''
                     A snippet of config for this spec.
                   '';

--- a/wrapperModules/n/neovim/normalize.nix
+++ b/wrapperModules/n/neovim/normalize.nix
@@ -223,7 +223,7 @@ in
 {
   inherit hasFennel mappedSpecs;
   infoPluginInitMain = lib.pipe mappedSpecs [
-    (builtins.filter (v: v.config or null != null))
+    (builtins.filter (v: v.config or null != null && v.config or "" != ""))
     (map (
       v:
       let


### PR DESCRIPTION
prevents generation of extra items than expected in the lua init sequence