### PR TITLE
fix(wrapperModules.neovim): match treesitter changes from nixpkgs

### DIFF
--- a/wrapperModules/n/neovim/default-config.nix
+++ b/wrapperModules/n/neovim/default-config.nix
@@ -188,9 +188,13 @@
                   v.value.collateGrammars or false
                   && v.value.data or null != null
                   && !builtins.isString v.value.data
-                  &&
-                    builtins.match "^vimplugin-(nvim-)?treesitter-(grammar|queries)-.*" (lib.getName v.value.data)
-                    != null;
+                  && (
+                    v.value.data.passthru.isTreesitterGrammar or false == true
+                    || v.value.data.passthru.isTreesitterQuery or false == true
+                    ||
+                      builtins.match "^vimplugin-(nvim-)?treesitter-(grammar|queries)-.*" (lib.getName v.value.data)
+                      != null
+                  );
               in
               {
                 grams = acc.grams ++ lib.optional isGram v.value.data;


### PR DESCRIPTION
collateGrammars setting now uses the new heuristic (old one left for backwards compat, but will be removed some months from now)