### PR TITLE
fix(wrapperModules.neovim): fetcher function for info plugin

### DIFF
--- a/wrapperModules/n/neovim/packDir.nix
+++ b/wrapperModules/n/neovim/packDir.nix
@@ -129,7 +129,7 @@ in
           if type(tbl) ~= "table" then return default end
           tbl = tbl[key]
         end
-        return tbl
+        return (tbl ~= nil) and tbl or default
       end
     })
   '';


### PR DESCRIPTION
should always return default if the value is nil or indexing fails