### PR TITLE
fix(wrapperModules.neovim): function options in settings are OK

### DIFF
--- a/wrapperModules/n/neovim/packDir.nix
+++ b/wrapperModules/n/neovim/packDir.nix
@@ -104,7 +104,7 @@ in
       plugins = ${lib.generators.toLua { } plugins4lua},
       settings = ${
         lib.generators.toLua { } (
-          config.settings
+          lib.filterAttrsRecursive (_: v: !builtins.isFunction v) config.settings
           // {
             nvim_lua_env =
               (config.package.lua.withPackages or pkgs.luajit.withPackages)


### PR DESCRIPTION
now filters out function-type options before they are converted to lua

declaring options in settings allows people to bypass the normal type restrictions of the the nixpkgs lua value type from the freeform module, so we need to handle that case.