### PR TITLE
feat(integrations): integration with other module systems

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Example:
   self,
 }:
 let
-  gitWrapped = self.wrappedModules.git.wrap {
+  gitWrapped = self.wrappers.git.wrap {
     inherit pkgs;
     settings = {
       user = {
@@ -154,7 +154,7 @@ pkgs.runCommand "git-test" { } ''
 If your module declares a list of valid platforms via its `meta.platforms` option, you should disable your test on the relevant platforms like so:
 
 ```nix
-if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.waybar.meta.platforms then
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappers.waybar.meta.platforms then
   pkgs.runCommand "waybar-test" { } ''
     "${waybarWrapped}/bin/waybar" --version | grep -q "${waybarWrapped.version}"
     touch $out

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ What if I told you, you can solve all those problems, and gain a really nice, co
 And it uses something you already know! The module system!
 
 ```nix
-inputs.nix-wrapper-modules.wrappedModules.alacritty.wrap {
+inputs.nix-wrapper-modules.wrappers.alacritty.wrap {
   inherit pkgs;
   settings.terminal.shell.program = "${pkgs.zsh}/bin/zsh";
   settings.terminal.shell.args = [ "-l" ];

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -201,12 +201,12 @@ let
     echo >> $out/src/SUMMARY.md
     echo '- [Intro](./home.md)' >> $out/src/SUMMARY.md
     echo '- [Getting Started](./getting-started.md)' >> $out/src/SUMMARY.md
-    echo '- [Core Options Set](./core.md)' >> $out/src/SUMMARY.md
-    echo '- [`wlib.modules.default`](./default.md)' >> $out/src/SUMMARY.md
     echo '- [Lib Functions](./lib-intro.md)' >> $out/src/SUMMARY.md
     echo '  - [`wlib`](./wlib.md)' >> $out/src/SUMMARY.md
     echo '  - [`wlib.types`](./types.md)' >> $out/src/SUMMARY.md
     echo '  - [`wlib.dag`](./dag.md)' >> $out/src/SUMMARY.md
+    echo '- [Core Options Set](./core.md)' >> $out/src/SUMMARY.md
+    echo '- [`wlib.modules.default`](./default.md)' >> $out/src/SUMMARY.md
     echo '- [Helper Modules](./helper-modules.md)' >> $out/src/SUMMARY.md
     ${mkSubLinks (builtins.removeAttrs module_docs [ "default" ])}
     echo '- [Wrapper Modules](./wrapper-modules.md)' >> $out/src/SUMMARY.md

--- a/docs/md/wrapper-modules.md
+++ b/docs/md/wrapper-modules.md
@@ -10,6 +10,6 @@ They include shortlist options for common configuration settings, and/or for pro
 
 The flake also exports wrapper modules that have been partially evaluated for convenience.
 
-This allows you to do something like `inputs.nix-wrapper-modules.wrappedModules.tmux.wrap { inherit pkgs; prefix = "C-Space"; }`, to build a package with a particular configuration quickly!
+This allows you to do something like `inputs.nix-wrapper-modules.wrappers.tmux.wrap { inherit pkgs; prefix = "C-Space"; }`, to build a package with a particular configuration quickly!
 
 You can then export that package, and somebody else could call `.wrap` on it as well to change it again!

--- a/flake.nix
+++ b/flake.nix
@@ -18,17 +18,53 @@
     in
     {
       lib = import ./lib { inherit lib; };
-      wrappedModules = lib.mapAttrs (_: v: (self.lib.evalModule v).config) self.lib.wrapperModules;
-      wrapperModules = lib.mapAttrs (
+      flakeModules = {
+        wrappers = ./parts.nix;
+        default = self.flakeModules.wrappers;
+      };
+      nixosModules = builtins.mapAttrs (name: value: {
+        inherit name value;
+        _file = value;
+        key = value;
+        __functor = self.lib.mkInstallModule;
+      }) self.lib.wrapperModules;
+      homeModules = builtins.mapAttrs (
         _: v:
+        v
+        // {
+          loc = [
+            "home"
+            "packages"
+          ];
+        }
+      ) self.nixosModules;
+      wrappers = lib.mapAttrs (_: v: (self.lib.evalModule v).config) self.lib.wrapperModules;
+      wrappedModules = lib.mapAttrs (
+        _:
         lib.warn ''
-          Attention: `wrapperModules` is deprecated, use `wrappedModules` instead
+          Attention: `inputs.nix-wrapper-modules.wrappedModules` is deprecated, use `inputs.nix-wrapper-modules.wrappers` instead
+
+          Apologies for any inconvenience this has caused, but they are only the config set of a module, not a module themselves.
+
+          In addition, it was very hard to tell the name apart from its actual module counterpart, and it was longer than convenient.
+
+          This will be the last time these output names are changing, as a flake-parts module has been added for users to import.
+
+          This output will be removed on August 31, 2026
+        ''
+      ) self.wrappers;
+      wrapperModules = lib.mapAttrs (
+        _:
+        lib.warn ''
+          Attention: `inputs.nix-wrapper-modules.wrapperModules` is deprecated, use `inputs.nix-wrapper-modules.wrappers` instead
 
           Apologies for any inconvenience this has caused. But the title `wrapperModules` should be specific to ones you can import.
 
           In the future, rather than being removed, this will be replaced by the unevaluated wrapper modules from `wlib.wrapperModules`
-        '' (self.lib.evalModule v).config
-      ) self.lib.wrapperModules;
+
+          This output will be replaced with module paths on April 30, 2026
+        ''
+      ) self.wrappers;
       formatter = forAllSystems (system: (fpkgs system).nixfmt-tree);
       templates = import ./templates;
       checks = forAllSystems (

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -39,11 +39,8 @@ in
           wlib.core
         ]
         ++ (evalArgs.modules or [ ]);
-        specialArgs = {
+        specialArgs = (evalArgs.specialArgs or { }) // {
           inherit (wlib) modulesPath;
-        }
-        // (evalArgs.specialArgs or { })
-        // {
           inherit wlib;
         };
       }
@@ -103,8 +100,139 @@ in
   evalPackage = module: (wlib.evalModules { modules = toList module; }).config.wrapper;
 
   /**
-    Creates a reusable wrapper module.
+    Produces a module for another module system,
+    that can be imported to configure and/or install a wrapper module.
 
+    *Arguments:*
+
+    ```nix
+    {
+      name, # string
+      value, # module or list of modules
+      optloc ? [ "wrappers" ],
+      loc ? [
+        "environment"
+        "systemPackages"
+      ],
+      as_list ? true,
+      # Also accepts any valid top-level module attribute
+      # other than `config` or `options`
+      ...
+    }:
+    ```
+
+    Creates a `wlib.types.subWrapperModule` option with an extra `enable` option at
+    the path indicated by `optloc ++ [ name ]`, with the default `optloc` being `[ "wrappers" ]`
+
+    Defines a list value at the path indicated by `loc` containing the `.wrapper` value of the submodule,
+    with the default `loc` being `[ "environment" "systemPackages" ]`
+
+    If `as_list` is false, it will set the value at the path indicated by `loc` as it is,
+    without putting it into a list.
+
+    This means it will create a module that can be used like so:
+
+    ```nix
+    # in a nixos module
+    { ... }: {
+      imports = [
+        (mkInstallModule { name = "?"; value = someWrapperModule; })
+      ];
+      config.wrappers."?" = {
+        enable = true;
+        env.EXTRAVAR = "TEST VALUE";
+      };
+    }
+    ```
+
+    ```nix
+    # in a home-manager module
+    { ... }: {
+      imports = [
+        (mkInstallModule { name = "?"; loc = [ "home" "packages" ]; value = someWrapperModule; })
+      ];
+      config.wrappers."?" = {
+        enable = true;
+        env.EXTRAVAR = "TEST VALUE";
+      };
+    }
+    ```
+
+    If needed, you can also grab the package directly with `config.wrappers."?".wrapper`
+
+    Note: This function will try to provide a `pkgs` to the `subWrapperModule` automatically.
+
+    If the target module evaluation does not provide a `pkgs` via its module arguments to use,
+    you will need to supply it to the submodule yourself later.
+  */
+  mkInstallModule =
+    {
+      optloc ? [ "wrappers" ],
+      loc ? [
+        "environment"
+        "systemPackages"
+      ],
+      as_list ? true,
+      name,
+      value,
+      ...
+    }@args:
+    {
+      pkgs ? null,
+      lib,
+      config,
+      ...
+    }:
+    # https://github.com/NixOS/nixpkgs/blob/c171bfa97744c696818ca23d1d0fc186689e45c7/lib/modules.nix#L615C1-L623C25
+    builtins.intersectAttrs {
+      _class = null;
+      _file = null;
+      key = null;
+      disabledModules = null;
+      imports = null;
+      meta = null;
+      freeformType = null;
+    } args
+    // {
+      options = lib.setAttrByPath (optloc ++ [ name ]) (
+        lib.mkOption {
+          default = { };
+          type = wlib.types.subWrapperModule (
+            (lib.toList value)
+            ++ [
+              {
+                config.pkgs = lib.mkIf (pkgs != null) pkgs;
+                options.enable = lib.mkEnableOption name;
+              }
+            ]
+          );
+        }
+      );
+      config = lib.setAttrByPath loc (
+        lib.mkIf
+          (lib.getAttrFromPath (
+            optloc
+            ++ [
+              name
+              "enable"
+            ]
+          ) config)
+          (
+            let
+              res = lib.getAttrFromPath (
+                optloc
+                ++ [
+                  name
+                  "wrapper"
+                ]
+              ) config;
+            in
+            if as_list then [ res ] else res
+          )
+      );
+    };
+
+  /**
     Imports `wlib.modules.default` then evaluates the module. It then returns `.config` so that `.wrap` is easily accessible!
 
     Use this when you want to quickly create a wrapper but without providing it a `pkgs` yet.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -47,11 +47,8 @@
       args
       // {
         modules = [ wlib.core ] ++ modules;
-        specialArgs = {
+        specialArgs = specialArgs // {
           inherit (wlib) modulesPath;
-        }
-        // specialArgs
-        // {
           inherit wlib;
         };
       }

--- a/parts.nix
+++ b/parts.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  flake-parts-lib,
+  config,
+  ...
+}:
+let
+  inherit (lib) types mkOption;
+  file = ./parts.nix;
+in
+{
+  _file = file;
+  key = file;
+  options.flake = mkOption {
+    type = types.submoduleWith {
+      modules = [
+        (
+          { options, ... }:
+          {
+            _file = file;
+            key = file;
+            options.wrappers = mkOption {
+              type = types.lazyAttrsOf ((import ./lib { inherit lib; }).types.subWrapperModuleWith { });
+              default = { };
+              description = ''
+                Submodule option for configuring and exporting wrapper modules!
+
+                https://github.com/BirdeeHub/nix-wrapper-modules
+              '';
+            };
+            options.wrapperModules = mkOption {
+              type = types.lazyAttrsOf types.deferredModule;
+              readOnly = true;
+              description = ''
+                contains importable module forms of your wrappers output
+
+                Read only. Modify `flake.wrappers` instead, this will reflect that option.
+
+                https://github.com/BirdeeHub/nix-wrapper-modules
+              '';
+            };
+            config.wrapperModules = (types.lazyAttrsOf types.deferredModule).merge options.wrappers.loc options.wrappers.definitionsWithLocations;
+          }
+        )
+      ];
+    };
+  };
+  options.perSystem =
+    let
+      inherit (config.flake) wrappers;
+    in
+    flake-parts-lib.mkPerSystemOption (
+      {
+        pkgs,
+        config,
+        ...
+      }:
+      {
+        _file = file;
+        key = file;
+        options.wrappers.pkgs = mkOption {
+          type = types.pkgs;
+          default = pkgs;
+          description = ''
+            The `pkgs` object used to build `outputs.wrappers` into packages
+          '';
+        };
+        options.wrappers.control_type = mkOption {
+          type = types.enum [
+            "build"
+            "exclude"
+          ];
+          default = "exclude";
+          description = ''
+            The behavior of `perSystem.wrappers.packages`
+
+            `exclude` will cause true values in the set to exclude that package.
+            `build` will cause only true values in the set to be built.
+          '';
+        };
+        options.wrappers.packages = mkOption {
+          type = types.attrsOf types.bool;
+          default = { };
+          description = ''
+            A set of booleans indicating which packages should be built.
+
+            Behavior of this option is determined by `perSystem.wrappers.control_type`
+          '';
+        };
+        config.packages = lib.pipe wrappers [
+          (
+            v:
+            let
+              args = lib.filterAttrs (_: v: v) config.wrappers.packages;
+            in
+            if config.wrappers.control_type == "build" then
+              builtins.intersectAttrs args wrappers
+            else
+              lib.filterAttrs (n: _: !args ? "${n}") wrappers
+          )
+          (builtins.mapAttrs (_: v: v.wrap { inherit (config.wrappers) pkgs; }))
+        ];
+      }
+    );
+}

--- a/templates/default.nix
+++ b/templates/default.nix
@@ -7,4 +7,8 @@
     path = ./neovim;
     description = "An example flake showing basic usage of the neovim module";
   };
+  flake-parts = {
+    path = ./flake-parts;
+    description = "An example flake using flake-parts with the provided flake-parts module";
+  };
 }

--- a/templates/flake-parts/flake.nix
+++ b/templates/flake-parts/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = ''
+    Uses flake-parts to set up the flake outputs:
+
+    `wrappers`, `wrapperModules` and `packages.*.*`
+  '';
+  inputs.wrappers.url = "github:BirdeeHub/nix-wrapper-modules";
+  inputs.wrappers.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+  inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+  outputs =
+    {
+      self,
+      nixpkgs,
+      wrappers,
+      flake-parts,
+      ...
+    }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ wrappers.flakeModules.wrappers ];
+      systems = nixpkgs.lib.platforms.all;
+
+      perSystem =
+        { pkgs, ... }:
+        {
+          # wrappers.pkgs = pkgs; # choose a different `pkgs`
+          wrappers.control_type = "exclude"; # | "build"  (default: "exclude")
+          wrappers.packages = {
+            hello = true; # <- set to true to exclude from being built into `packages.*.*` flake output
+          };
+        };
+      flake.wrappers.hello = ./hello.nix;
+      flake.wrappers.tmux =
+        { wlib, pkgs, ... }:
+        {
+          imports = [ wlib.wrapperModules.tmux ];
+          plugins = with pkgs.tmuxPlugins; [ onedark-theme ];
+        };
+    };
+}

--- a/templates/flake-parts/hello.nix
+++ b/templates/flake-parts/hello.nix
@@ -1,0 +1,19 @@
+{
+  config,
+  wlib,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [ wlib.modules.default ];
+  options.greeting = lib.mkOption {
+    type = lib.types.str;
+    default = "hello";
+    description = "The greeting to use";
+  };
+  config.package = pkgs.hello;
+  config.flags = {
+    "--greeting" = config.greeting;
+  };
+}

--- a/templates/flake/flake.nix
+++ b/templates/flake/flake.nix
@@ -20,7 +20,7 @@
         ${wrapper.config.binName} = wrapper.config.wrap { pkgs = prev; };
       };
       wrapperModules.default = module;
-      wrappedModules.default = wrapper.config;
+      wrappers.default = wrapper.config;
       packages = forAllSystems (
         system:
         let

--- a/templates/neovim/flake.nix
+++ b/templates/neovim/flake.nix
@@ -34,9 +34,9 @@
         default = module;
         neovim = self.wrapperModules.default;
       };
-      wrappedModules = {
+      wrappers = {
         default = wrapper.config;
-        neovim = self.wrappedModules.default;
+        neovim = self.wrappers.default;
       };
       packages = forAllSystems (
         system:

--- a/wrapperModules/a/atool/check.nix
+++ b/wrapperModules/a/atool/check.nix
@@ -1,6 +1,6 @@
 { pkgs, self }:
 let
-  atoolWrapped = self.wrappedModules.atool.wrap {
+  atoolWrapped = self.wrappers.atool.wrap {
     inherit pkgs;
     tools.enable = true;
     tools.paths.zip = "${pkgs.zip}/bin/zip";

--- a/wrapperModules/c/claude-code/check.nix
+++ b/wrapperModules/c/claude-code/check.nix
@@ -3,7 +3,7 @@
   self,
 }:
 let
-  claudeCodeWrapped = self.wrappedModules.claude-code.wrap {
+  claudeCodeWrapped = self.wrappers.claude-code.wrap {
     inherit pkgs;
 
     mcpConfig = {

--- a/wrapperModules/g/git/check.nix
+++ b/wrapperModules/g/git/check.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  gitWrapped = self.wrappedModules.git.wrap {
+  gitWrapped = self.wrappers.git.wrap {
     inherit pkgs;
     settings = {
       user = {

--- a/wrapperModules/h/helix/check.nix
+++ b/wrapperModules/h/helix/check.nix
@@ -5,7 +5,7 @@
 
 let
   helixWrapped =
-    (self.wrappedModules.helix.apply {
+    (self.wrappers.helix.apply {
       inherit pkgs;
     }).wrapper;
 

--- a/wrapperModules/j/jujutsu/check.nix
+++ b/wrapperModules/j/jujutsu/check.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  jujutsuWrapped = self.wrappedModules.jujutsu.wrap {
+  jujutsuWrapped = self.wrappers.jujutsu.wrap {
     inherit pkgs;
     settings = {
       user = {

--- a/wrapperModules/m/mako/check.nix
+++ b/wrapperModules/m/mako/check.nix
@@ -5,13 +5,13 @@
 
 let
   makoWrapped =
-    (self.wrappedModules.mako.apply {
+    (self.wrappers.mako.apply {
       inherit pkgs;
       settings.icon-location = "left";
     }).wrapper;
 
 in
-if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.mako.meta.platforms then
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappers.mako.meta.platforms then
   pkgs.runCommand "mako-test" { } ''
     "${makoWrapped}/bin/mako" --help | grep -q "mako"
     grep -q --no-ignore-case -- "--config" "${makoWrapped}/bin/mako"

--- a/wrapperModules/m/mpv/check.nix
+++ b/wrapperModules/m/mpv/check.nix
@@ -5,7 +5,7 @@
 
 let
   mpvWrapped =
-    (self.wrappedModules.mpv.apply {
+    (self.wrappers.mpv.apply {
       inherit pkgs;
       scripts = [
         pkgs.mpvScripts.visualizer

--- a/wrapperModules/n/neovim/check.nix
+++ b/wrapperModules/n/neovim/check.nix
@@ -5,7 +5,7 @@
 }:
 let
   runpkg = pkg: "${pkg}/bin/${pkg.configuration.binName} --headless";
-  nvimpkg = self.wrappedModules.neovim.wrap [
+  nvimpkg = self.wrappers.neovim.wrap [
     { inherit pkgs; }
     (
       {

--- a/wrapperModules/n/niri/check.nix
+++ b/wrapperModules/n/niri/check.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  niriWrapped = self.wrappedModules.niri.wrap {
+  niriWrapped = self.wrappers.niri.wrap {
     inherit pkgs;
 
     settings = {
@@ -97,7 +97,7 @@ let
     };
   };
 in
-if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.niri.meta.platforms then
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappers.niri.meta.platforms then
   pkgs.runCommand "niri-test" { } ''
     cat ${niriWrapped}/bin/niri
     "${niriWrapped}/bin/niri" --version | grep -q "${niriWrapped.version}"

--- a/wrapperModules/n/notmuch/check.nix
+++ b/wrapperModules/n/notmuch/check.nix
@@ -5,7 +5,7 @@
 
 let
   notmuchWrapped =
-    (self.wrappedModules.notmuch.apply {
+    (self.wrappers.notmuch.apply {
       inherit pkgs;
       settings = {
         database.path = "/tmp/test-mail";

--- a/wrapperModules/n/nushell/check.nix
+++ b/wrapperModules/n/nushell/check.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  nushellWrapped = self.wrappedModules.nushell.wrap {
+  nushellWrapped = self.wrappers.nushell.wrap {
     inherit pkgs;
   };
 

--- a/wrapperModules/r/rofi/check.nix
+++ b/wrapperModules/r/rofi/check.nix
@@ -5,14 +5,14 @@
 
 let
   rofiWrapped =
-    (self.wrappedModules.rofi.apply {
+    (self.wrappers.rofi.apply {
       inherit pkgs;
 
       theme.foo = "bar";
     }).wrapper;
 
 in
-if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.rofi.meta.platforms then
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappers.rofi.meta.platforms then
   pkgs.runCommand "rofi-test" { } ''
     # Rofi attempts to create some directories when first ran which doesn't work in a nix build
     export XDG_CACHE_HOME=/tmp

--- a/wrapperModules/w/waybar/check.nix
+++ b/wrapperModules/w/waybar/check.nix
@@ -3,7 +3,7 @@
   self,
 }:
 let
-  waybarWrapped = self.wrappedModules.waybar.wrap {
+  waybarWrapped = self.wrappers.waybar.wrap {
     inherit pkgs;
 
     settings = {
@@ -17,7 +17,7 @@ let
   };
 
 in
-if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappedModules.waybar.meta.platforms then
+if builtins.elem pkgs.stdenv.hostPlatform.system self.wrappers.waybar.meta.platforms then
   pkgs.runCommand "waybar-test" { } ''
     "${waybarWrapped}/bin/waybar" --version | grep -q "${waybarWrapped.version}"
     touch $out

--- a/wrapperModules/w/wezterm/check.nix
+++ b/wrapperModules/w/wezterm/check.nix
@@ -3,7 +3,7 @@
   self,
 }:
 let
-  weztermWrapped = self.wrappedModules.wezterm.wrap (
+  weztermWrapped = self.wrappers.wezterm.wrap (
     { lib, ... }:
     {
       inherit pkgs;

--- a/wrapperModules/x/xplr/check.nix
+++ b/wrapperModules/x/xplr/check.nix
@@ -3,7 +3,7 @@
   self,
 }:
 let
-  xplr = self.wrappedModules.xplr.wrap (
+  xplr = self.wrappers.xplr.wrap (
     { lib, ... }:
     {
       inherit pkgs;
@@ -36,7 +36,7 @@ let
       };
     }
   );
-  xplr_linux_only_check = self.wrappedModules.xplr.wrap (
+  xplr_linux_only_check = self.wrappers.xplr.wrap (
     { lib, ... }:
     {
       inherit pkgs;


### PR DESCRIPTION
changed `outputs.wrappedModules` to `outputs.wrappers` (Sorry! But also this is much better and the repo is only 2 months old still. You have 8 months to change it before the old one is removed. This name will not change again)

Added flake-parts module for setting up your outputs, (`wrapperModules`, `wrappers`, and `packages.*.*`)

Added flake-parts template.

Added function for creating nixos and home manager modules from any wrapper module.

Added flakeModules nixosModules and homeModules outputs to the main flake.

Improved documentation.

Did the treewide update for checks from outputs.wrappedModules to outputs.wrappers

Added specific dates of removal to some deprecations.