### PR TITLE
fix(lib.types.nonEmptyLine): nonEmptyline -> nonEmptyLine

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -203,7 +203,7 @@ in
           )
         ) package (wlib.dag.unwrapSort "overrides" config.overrides);
       type = lib.types.addCheck wlib.types.stringable (
-        v: if builtins.isString v then wlib.types.nonEmptyline.check v else true
+        v: if builtins.isString v then wlib.types.nonEmptyLine.check v else true
       );
       description = ''
         The base package to wrap.
@@ -373,7 +373,7 @@ in
       '';
     };
     binName = lib.mkOption {
-      type = wlib.types.nonEmptyline;
+      type = wlib.types.nonEmptyLine;
       default = baseNameOf (
         builtins.addErrorContext ''
           `config.package`: ${config.package} is not a derivation.
@@ -387,7 +387,7 @@ in
       '';
     };
     exePath = lib.mkOption {
-      type = wlib.types.nonEmptyline;
+      type = wlib.types.nonEmptyLine;
       default = lib.removePrefix "/" (
         lib.removePrefix "${config.package}" (
           builtins.addErrorContext ''

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -311,8 +311,8 @@
   /**
     A single-line, non-empty string
   */
-  nonEmptyline = lib.mkOptionType {
-    name = "nonEmptyline";
+  nonEmptyLine = lib.mkOptionType {
+    name = "nonEmptyLine";
     description = "non-empty line";
     descriptionClass = "noun";
     check =
@@ -320,6 +320,7 @@
       lib.types.str.check x && builtins.match "[ \t\n]*" x == null && builtins.match "[^\n\r]*" != null;
     inherit (lib.types.str) merge;
   };
+  nonEmptyline = lib.warn "`wlib.types.nonEmptyline` is deprecated due to having a mistake in its name, use `wlib.types.nonEmptyLine`" wlib.types.nonEmptyLine;
 
   /**
     Arguments:

--- a/wrapperModules/n/neovim/module.nix
+++ b/wrapperModules/n/neovim/module.nix
@@ -61,21 +61,21 @@ let
               description = "placeholder option";
             };
             enabled_variable = lib.mkOption {
-              type = wlib.types.nonEmptyline;
+              type = wlib.types.nonEmptyLine;
               default = "${name}_host_prog";
               description = ''
                 vim.g.<value> will be set to the path to this wrapped host when the nvim host is enabled
               '';
             };
             disabled_variable = lib.mkOption {
-              type = wlib.types.nonEmptyline;
+              type = wlib.types.nonEmptyLine;
               default = "loaded_${name}_provider";
               description = ''
                 vim.g.<value> will be set to 0 when the nvim host is disabled
               '';
             };
             var_path = lib.mkOption {
-              type = wlib.types.nonEmptyline;
+              type = wlib.types.nonEmptyLine;
               default = "${placeholder "out"}/bin/${config.binName}-${name}";
               description = ''
                 The path to be added to `vim.g.<enabled_variable>`
@@ -98,7 +98,7 @@ let
               '';
             };
             package = lib.mkOption {
-              type = wlib.types.nonEmptyline;
+              type = wlib.types.nonEmptyLine;
               default = "${hostConfig.wrapper}/bin/${hostConfig.binName}";
               description = ''
                 The full path to be added to the `PATH` alongside the main nvim wrapper.
@@ -373,7 +373,7 @@ in
           };
 
           info_plugin_name = lib.mkOption {
-            type = lib.types.addCheck wlib.types.nonEmptyline (v: !lib.hasInfix "." v);
+            type = lib.types.addCheck wlib.types.nonEmptyLine (v: !lib.hasInfix "." v);
             default = "nix-info";
             description = ''
               The name to use to require the info plugin


### PR DESCRIPTION
the old one can remain with a warning basically indefinitely, but the current name is definitely a typographical error