### PR TITLE
refactor(wrapperModules.vim): remove extra test cmd

### DIFF
--- a/wrapperModules/v/vim/check.nix
+++ b/wrapperModules/v/vim/check.nix
@@ -55,7 +55,7 @@ pkgs.runCommand "vim-test" { } ''
     exit 1
   fi
 
-  res=$('${vimWrapped}/bin/vim' -es +':redir >> /dev/stdout' +'set tabstop?' +'scriptnames' +'q')
+  res=$('${vimWrapped}/bin/vim' -es +':redir >> /dev/stdout' +'set tabstop?' +'q')
 
   if ! echo "''${res}" | grep -q 'tabstop=17'; then
     echo 'Vim does not apply configuration.'


### PR DESCRIPTION
Caught it after https://github.com/BirdeeHub/nix-wrapper-modules/pull/229 got merged.