### PR TITLE
feat(wrapperModules.btop): support themes

### DIFF
--- a/wrapperModules/b/btop/module.nix
+++ b/wrapperModules/b/btop/module.nix
@@ -25,7 +25,6 @@ let
     name: theme:
     if builtins.isPath theme || lib.isStorePath theme then theme else pkgs.writeText "btop.theme" theme;
 
-  binNameEsc = lib.escapeShellArg config.binName;
   themesDir = "${builtins.placeholder "out"}/themes";
 in
 {


### PR DESCRIPTION
Added support for Btop themes similar to [how home-manager does it](https://github.com/nix-community/home-manager/blob/63a87808f5f9b6e4195a1d33f6ea25d23f4aa0df/modules/programs/btop.nix#L131-L141). Based on our discussion in https://github.com/BirdeeHub/nix-wrapper-modules/pull/204.