### PR TITLE
fix(wrapperModules.neovim): regression to host info in info plugin

### DIFF
--- a/wrapperModules/n/neovim/packDir.nix
+++ b/wrapperModules/n/neovim/packDir.nix
@@ -37,10 +37,7 @@ let
             name = v.attrname;
             value = {
               bin_path =
-                if v ? bin_path then
-                  builtins.toJSON "${placeholder "out"}/bin/${config.binName}-${v.attrname}"
-                else
-                  null;
+                if v ? bin_path then "${placeholder "out"}/bin/${config.binName}-${v.attrname}" else null;
               var_path = lib.generators.mkLuaInline "vim.g[ ${builtins.toJSON v.enabled_variable} ]";
               inherit (v) disabled_variable enabled_variable;
             };


### PR DESCRIPTION
hosts.*.bin_path was being double escaped