### PR TITLE
feat(modules.makeWrapper): wrapperVariants

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -5,6 +5,7 @@
   lib,
   wlib,
   nixdoc,
+  warningsAreErrors ? true,
   ...
 }:
 let
@@ -70,7 +71,7 @@ let
             )
           ];
       get_options = key: mod: {
-        options = builtins.removeAttrs (eval_mod key mod).options corelist;
+        options = removeAttrs (eval_mod key mod).options corelist;
         inherit key;
       };
       optionsList =
@@ -78,7 +79,7 @@ let
         ++ lib.optional include_core {
           key = "lib/core.nix";
           options =
-            builtins.removeAttrs
+            removeAttrs
               (wlib.evalModule {
                 inherit pkgs;
                 package = lib.mkOverride 9001 pkgs.hello;
@@ -102,6 +103,7 @@ let
       commands = map (
         v:
         mkMsg v.key (nixosOptionsDoc {
+          inherit warningsAreErrors;
           inherit (v) options;
         })
       ) optionsList;
@@ -140,7 +142,8 @@ let
             post = "";
           } evaled.config.meta.description;
           coreopts = nixosOptionsDoc {
-            options = builtins.removeAttrs evaled.options [ "_module" ];
+            inherit warningsAreErrors;
+            options = removeAttrs evaled.options [ "_module" ];
           };
         in
         ''
@@ -208,7 +211,7 @@ let
     echo '- [Core Options Set](./core.md)' >> $out/src/SUMMARY.md
     echo '- [`wlib.modules.default`](./default.md)' >> $out/src/SUMMARY.md
     echo '- [Helper Modules](./helper-modules.md)' >> $out/src/SUMMARY.md
-    ${mkSubLinks (builtins.removeAttrs module_docs [ "default" ])}
+    ${mkSubLinks (removeAttrs module_docs [ "default" ])}
     echo '- [Wrapper Modules](./wrapper-modules.md)' >> $out/src/SUMMARY.md
     ${mkSubLinks wrapper_docs}
   '';

--- a/lib/core.nix
+++ b/lib/core.nix
@@ -387,7 +387,7 @@ in
       '';
     };
     exePath = lib.mkOption {
-      type = wlib.types.nonEmptyLine;
+      type = lib.types.nullOr wlib.types.nonEmptyLine;
       default = lib.removePrefix "/" (
         lib.removePrefix "${config.package}" (
           builtins.addErrorContext ''

--- a/modules/makeWrapper/default.nix
+++ b/modules/makeWrapper/default.nix
@@ -1,4 +1,38 @@
-{ config, callPackage, ... }@args:
-callPackage (
-  if config.wrapperImplementation or "nix" == "nix" then ./makeWrapperNix.nix else ./makeWrapper.nix
-) args
+variant:
+{
+  config,
+  lib,
+  wlib,
+  callPackage,
+  ...
+}@args:
+let
+  call =
+    v:
+    callPackage
+      (if config.wrapperImplementation or "nix" == "nix" then ./makeWrapperNix.nix else ./makeWrapper.nix)
+      (
+        v
+        // {
+          ${if builtins.isAttrs wlib then null else "wlib"} = import ../../lib {
+            inherit lib;
+          };
+        }
+      );
+in
+if variant == null || variant == true then
+  lib.pipe (config.wrapperVariants or { }) [
+    (lib.mapAttrsToList (n: v: if v.enable or false then call (args // { config = v; }) else null))
+    (builtins.filter (v: v != null))
+    (list: (if variant != true then [ (call args) ] else [ ]) ++ list)
+    (builtins.concatStringsSep "\n")
+  ]
+else if variant == false then
+  call args
+else if builtins.isString variant then
+  if config.wrapperVariants.${variant}.enable or false then
+    call (args // { config = config.wrapperVariants.${variant}; })
+  else
+    ""
+else
+  ""

--- a/modules/makeWrapper/makeWrapperNix.nix
+++ b/modules/makeWrapper/makeWrapperNix.nix
@@ -30,14 +30,15 @@ let
     wlib.dag.sortAndUnwrap {
       name = "addFlag";
       dag =
-        lib.optionals (config.flags != { }) (
+        lib.optionals (config.flags or { } != { }) (
           generateArgsFromFlags (config.flagSeparator or " ") config.flags
         )
-        ++ lib.optionals (config.addFlag != [ ]) config.addFlag;
+        ++ lib.optionals (config.addFlag or { } != [ ]) config.addFlag;
       mapIfOk =
         v:
         let
-          esc-fn = if v.esc-fn or null != null then v.esc-fn else config.escapingFunction;
+          esc-fn =
+            if v.esc-fn or null != null then v.esc-fn else (config.escapingFunction or lib.escapeShellArg);
         in
         if builtins.isList v.data then builtins.concatStringsSep " " (map esc-fn v.data) else esc-fn v.data;
     }
@@ -45,11 +46,12 @@ let
   postFlagStr = builtins.concatStringsSep " " (
     wlib.dag.sortAndUnwrap {
       name = "appendFlag";
-      dag = config.appendFlag;
+      dag = (config.appendFlag or [ ]);
       mapIfOk =
         v:
         let
-          esc-fn = if v.esc-fn or null != null then v.esc-fn else config.escapingFunction;
+          esc-fn =
+            if v.esc-fn or null != null then v.esc-fn else (config.escapingFunction or lib.escapeShellArg);
         in
         if builtins.isList v.data then builtins.concatStringsSep " " (map esc-fn v.data) else esc-fn v.data;
     }
@@ -59,15 +61,15 @@ let
     echo ${lib.escapeShellArg partial} >> $out/bin/${config.binName}
   '';
   shellcmdsdal =
-    wlib.dag.lmap (var: esc-fn: wrapcmd "unset ${esc-fn var}") config.unsetVar
+    wlib.dag.lmap (var: esc-fn: wrapcmd "unset ${esc-fn var}") (config.unsetVar or [ ])
     ++ wlib.dag.mapDagToDal (
       n: v: esc-fn:
       wrapcmd "wrapperSetEnv ${esc-fn n} ${esc-fn v}"
-    ) config.env
+    ) (config.env or { })
     ++ wlib.dag.mapDagToDal (
       n: v: esc-fn:
       wrapcmd "wrapperSetEnvDefault ${esc-fn n} ${esc-fn v}"
-    ) config.envDefault
+    ) (config.envDefault or { })
     ++ wlib.dag.lmap (
       tuple: esc-fn:
       let
@@ -76,7 +78,7 @@ let
         val = elemAt tuple 2;
       in
       wrapcmd "wrapperPrefixEnv ${esc-fn env} ${esc-fn sep} ${esc-fn val}"
-    ) config.prefixVar
+    ) (config.prefixVar or [ ])
     ++ wlib.dag.lmap (
       tuple: esc-fn:
       let
@@ -85,7 +87,7 @@ let
         val = elemAt tuple 2;
       in
       wrapcmd "wrapperSuffixEnv ${esc-fn env} ${esc-fn sep} ${esc-fn val}"
-    ) config.suffixVar
+    ) (config.suffixVar or [ ])
     ++ wlib.dag.lmap (
       tuple: esc-fn:
       let
@@ -95,7 +97,7 @@ let
         cmd = "wrapperPrefixEnv ${esc-fn env} ${esc-fn sep} ";
       in
       ''echo ${lib.escapeShellArg cmd}"$(cat ${esc-fn val})" >> $out/bin/${config.binName}''
-    ) config.prefixContent
+    ) (config.prefixContent or [ ])
     ++ wlib.dag.lmap (
       tuple: esc-fn:
       let
@@ -105,25 +107,36 @@ let
         cmd = "wrapperSuffixEnv ${esc-fn env} ${esc-fn sep} ";
       in
       ''echo ${lib.escapeShellArg cmd}"$(cat ${esc-fn val})" >> $out/bin/${config.binName}''
-    ) config.suffixContent
-    ++ wlib.dag.lmap (dir: esc-fn: wrapcmd "cd ${esc-fn dir}") config.chdir
-    ++ wlib.dag.lmap (cmd: _: wrapcmd cmd) config.runShell;
+    ) (config.suffixContent or [ ])
+    ++ wlib.dag.lmap (dir: esc-fn: wrapcmd "cd ${esc-fn dir}") (config.chdir or [ ])
+    ++ wlib.dag.lmap (cmd: _: wrapcmd cmd) (config.runShell or [ ]);
 
-  arg0 = if config.argv0 == null then "\"$0\"" else config.escapingFunction config.argv0;
+  arg0 =
+    if builtins.isString (config.argv0 or null) then
+      (config.escapingFunction or lib.escapeShellArg) config.argv0
+    else
+      "\"$0\"";
   finalcmd = ''${
-    if config.exePath == "" then "${config.package}" else "${config.package}/${config.exePath}"
+    if !builtins.isString (config.exePath or null) || config.exePath == "" then
+      "${config.package}"
+    else
+      "${config.package}/${config.exePath}"
   } ${preFlagStr} "$@" ${postFlagStr}'';
 
-  shellcmds = lib.optionals (shellcmdsdal != [ ] || lib.isFunction config.argv0type) (
+  shellcmds = lib.optionals (shellcmdsdal != [ ] || lib.isFunction (config.argv0type or null)) (
     wlib.dag.sortAndUnwrap {
       name = "makeWrapperNix";
       dag =
         shellcmdsdal
-        ++ lib.optional (lib.isFunction config.argv0type) {
+        ++ lib.optional (lib.isFunction (config.argv0type or null)) {
           name = "NIX_RUN_MAIN_PACKAGE";
           data = _: wrapcmd (config.argv0type finalcmd);
         };
-      mapIfOk = v: v.data (if (v.esc-fn or null) != null then v.esc-fn else config.escapingFunction);
+      mapIfOk =
+        v:
+        v.data (
+          if (v.esc-fn or null) != null then v.esc-fn else (config.escapingFunction or lib.escapeShellArg)
+        );
     }
   );
 
@@ -132,12 +145,18 @@ let
   prefixvarfunc = /* bash */ ''wrapperPrefixEnv() { export "$1=''${!1:+$3$2}''${!1:-$3}"; }'';
   suffixvarfunc = /* bash */ ''wrapperSuffixEnv() { export "$1=''${!1:+''${!1}$2}$3"; }'';
   prefuncs =
-    lib.optional (config.env != { }) setvarfunc
-    ++ lib.optional (config.envDefault != { }) setvardefaultfunc
-    ++ lib.optional (config.prefixVar != [ ] || config.prefixContent != [ ]) prefixvarfunc
-    ++ lib.optional (config.suffixVar != [ ] || config.suffixContent != [ ]) suffixvarfunc;
+    lib.optional (config.env or { } != { }) setvarfunc
+    ++ lib.optional (config.envDefault or { } != { }) setvardefaultfunc
+    ++ lib.optional (config.prefixVar or [ ] != [ ] || config.prefixContent or [ ] != [ ]) prefixvarfunc
+    ++ lib.optional (
+      config.suffixVar or [ ] != [ ] || config.suffixContent or [ ] != [ ]
+    ) suffixvarfunc;
 in
-if config.binName == "" then
+if
+  !builtins.isString (config.binName or null)
+  || config.binName == ""
+  || !(lib.isStringLike (config.package or null))
+then
   ""
 else
   ''
@@ -145,6 +164,8 @@ else
     echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > $out/bin/${config.binName}
     ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
     ${builtins.concatStringsSep "\n" shellcmds}
-    ${lib.optionalString (!lib.isFunction config.argv0type) (wrapcmd "exec -a ${arg0} ${finalcmd}")}
+    ${lib.optionalString (!lib.isFunction (config.argv0type or null)) (
+      wrapcmd "exec -a ${arg0} ${finalcmd}"
+    )}
     chmod +x $out/bin/${config.binName}
   ''

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -1,22 +1,25 @@
-{
-  wrapperFunction = import ./.;
-  __functor =
-    self:
+let
+  options_module =
+    excluded: is_top:
     {
       config,
+      options,
       wlib,
       lib,
+      mainConfig ? null,
+      mainOpts ? null,
       ...
     }:
     {
-      options.argv0type = lib.mkOption {
+      _file = ./module.nix;
+      options.${if !(excluded.argv0type or false) then "argv0type" else null} = lib.mkOption {
         type =
           with lib.types;
           either (enum [
             "resolve"
             "inherit"
           ]) (functionTo str);
-        default = "inherit";
+        default = if mainConfig != null && config.mirror or false then mainConfig.argv0type else "inherit";
         description = ''
           `argv0` overrides this option if not null or unset
 
@@ -52,9 +55,9 @@
           but by default it is still last.
         '';
       };
-      options.argv0 = lib.mkOption {
+      options.${if !(excluded.argv0 or false) then "argv0" else null} = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
-        default = null;
+        default = if mainConfig != null && config.mirror or false then mainConfig.argv0 else null;
         description = ''
           --argv0 NAME
 
@@ -64,18 +67,18 @@
           overrides the setting from `argv0type` if set.
         '';
       };
-      options.unsetVar = lib.mkOption {
+      options.${if !(excluded.unsetVar or false) then "unsetVar" else null} = lib.mkOption {
         type = wlib.types.dalWithEsc lib.types.str;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.unsetVar else [ ];
         description = ''
           --unset VAR
 
           Remove VAR from the environment.
         '';
       };
-      options.runShell = lib.mkOption {
+      options.${if !(excluded.runShell or false) then "runShell" else null} = lib.mkOption {
         type = wlib.types.dalWithEsc wlib.types.stringable;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.runShell else [ ];
         description = ''
           --run COMMAND
 
@@ -90,9 +93,9 @@
           If no name is provided, it cannot be targeted.
         '';
       };
-      options.chdir = lib.mkOption {
+      options.${if !(excluded.chdir or false) then "chdir" else null} = lib.mkOption {
         type = wlib.types.dalWithEsc wlib.types.stringable;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.chdir else [ ];
         description = ''
           --chdir DIR
 
@@ -100,9 +103,9 @@
           Use instead of `--run "cd DIR"`.
         '';
       };
-      options.addFlag = lib.mkOption {
+      options.${if !(excluded.addFlag or false) then "addFlag" else null} = lib.mkOption {
         type = wlib.types.wrapperFlag;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.addFlag else [ ];
         example = [
           "-v"
           "-f"
@@ -133,9 +136,9 @@
           If no name is provided, it cannot be targeted.
         '';
       };
-      options.appendFlag = lib.mkOption {
+      options.${if !(excluded.appendFlag or false) then "appendFlag" else null} = lib.mkOption {
         type = wlib.types.wrapperFlag;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.appendFlag else [ ];
         example = [
           "-v"
           "-f"
@@ -164,9 +167,9 @@
           If no name is provided, it cannot be targeted.
         '';
       };
-      options.prefixVar = lib.mkOption {
+      options.${if !(excluded.prefixVar or false) then "prefixVar" else null} = lib.mkOption {
         type = wlib.types.wrapperFlags 3;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.prefixVar else [ ];
         example = [
           [
             "LD_LIBRARY_PATH"
@@ -185,9 +188,9 @@
           Prefix ENV with VAL, separated by SEP.
         '';
       };
-      options.suffixVar = lib.mkOption {
+      options.${if !(excluded.suffixVar or false) then "suffixVar" else null} = lib.mkOption {
         type = wlib.types.wrapperFlags 3;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.suffixVar else [ ];
         example = [
           [
             "LD_LIBRARY_PATH"
@@ -206,9 +209,9 @@
           Suffix ENV with VAL, separated by SEP.
         '';
       };
-      options.prefixContent = lib.mkOption {
+      options.${if !(excluded.prefixContent or false) then "prefixContent" else null} = lib.mkOption {
         type = wlib.types.wrapperFlags 3;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.prefixContent else [ ];
         description = ''
           ```nix
           [
@@ -228,9 +231,9 @@
           ```
         '';
       };
-      options.suffixContent = lib.mkOption {
+      options.${if !(excluded.suffixContent or false) then "suffixContent" else null} = lib.mkOption {
         type = wlib.types.wrapperFlags 3;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.suffixContent else [ ];
         description = ''
           ```nix
           [
@@ -250,9 +253,9 @@
           ```
         '';
       };
-      options.flags = lib.mkOption {
+      options.${if !(excluded.flags or false) then "flags" else null} = lib.mkOption {
         type = (import ./genArgsFromFlags.nix { inherit lib wlib; }).flagDag;
-        default = { };
+        default = if mainConfig != null && config.mirror or false then mainConfig.flags else { };
         example = {
           "--config" = "\${./nixPath}";
         };
@@ -273,17 +276,17 @@
           which will cause the resulting wrapper argument to be sorted accordingly
         '';
       };
-      options.flagSeparator = lib.mkOption {
+      options.${if !(excluded.flagSeparator or false) then "flagSeparator" else null} = lib.mkOption {
         type = lib.types.str;
-        default = " ";
+        default = if mainConfig != null && config.mirror or false then mainConfig.flagSeparator else " ";
         description = ''
           Separator between flag names and values when generating args from flags.
           `" "` for `--flag value` or `"="` for `--flag=value`
         '';
       };
-      options.extraPackages = lib.mkOption {
+      options.${if !(excluded.extraPackages or false) then "extraPackages" else null} = lib.mkOption {
         type = lib.types.listOf lib.types.package;
-        default = [ ];
+        default = if mainConfig != null && config.mirror or false then mainConfig.extraPackages else [ ];
         description = ''
           Additional packages to add to the wrapper's runtime PATH.
           This is useful if the wrapped program needs additional libraries or tools to function correctly.
@@ -291,104 +294,21 @@
           Adds all its entries to the DAG under the name `NIX_PATH_ADDITIONS`
         '';
       };
-      options.runtimeLibraries = lib.mkOption {
-        type = lib.types.listOf lib.types.package;
-        default = [ ];
-        description = ''
-          Additional libraries to add to the wrapper's runtime LD_LIBRARY_PATH.
-          This is useful if the wrapped program needs additional libraries or tools to function correctly.
+      options.${if !(excluded.runtimeLibraries or false) then "runtimeLibraries" else null} =
+        lib.mkOption
+          {
+            type = lib.types.listOf lib.types.package;
+            default = if mainConfig != null && config.mirror or false then mainConfig.runtimeLibraries else [ ];
+            description = ''
+              Additional libraries to add to the wrapper's runtime LD_LIBRARY_PATH.
+              This is useful if the wrapped program needs additional libraries or tools to function correctly.
 
-          Adds all its entries to the DAG under the name `NIX_LIB_ADDITIONS`
-        '';
-      };
-      options.env = lib.mkOption {
-        type = wlib.types.dagWithEsc wlib.types.stringable;
-        default = { };
-        example = {
-          "XDG_DATA_HOME" = "/somewhere/on/your/machine";
-        };
-        description = ''
-          Environment variables to set in the wrapper.
-
-          This option takes a set.
-
-          Any entry can instead be of type `{ data, before ? [], after ? [], esc-fn ? null }`
-
-          This will cause it to be added to the DAG,
-          which will cause the resulting wrapper argument to be sorted accordingly
-        '';
-      };
-      options.envDefault = lib.mkOption {
-        type = wlib.types.dagWithEsc wlib.types.stringable;
-        default = { };
-        example = {
-          "XDG_DATA_HOME" = "/only/if/not/set";
-        };
-        description = ''
-          Environment variables to set in the wrapper.
-
-          Like env, but only adds the variable if not already set in the environment.
-
-          This option takes a set.
-
-          Any entry can instead be of type `{ data, before ? [], after ? [], esc-fn ? null }`
-
-          This will cause it to be added to the DAG,
-          which will cause the resulting wrapper argument to be sorted accordingly
-        '';
-      };
-      options.escapingFunction = lib.mkOption {
-        type = lib.types.functionTo lib.types.str;
-        default = lib.escapeShellArg;
-        defaultText = "lib.escapeShellArg";
-        description = ''
-          The function to use to escape shell values
-
-          Caution: When using `shell` or `binary` implementations,
-          these will be expanded at BUILD time.
-
-          You should probably leave this as is when using either of those implementations.
-
-          However, when using the `nix` implementation, they will expand at runtime!
-          Which means `wlib.escapeShellArgWithEnv` may prove to be a useful substitute!
-        '';
-      };
-      options.wrapperImplementation = lib.mkOption {
-        type = lib.types.enum [
-          "nix"
-          "shell"
-          "binary"
-        ];
-        default = "nix";
-        description = ''
-          the `nix` implementation is the default
-
-          It makes the `escapingFunction` most relevant.
-
-          This is because the `shell` and `binary` implementations
-          use `pkgs.makeWrapper` or `pkgs.makeBinaryWrapper`,
-          and arguments to these functions are passed at BUILD time.
-
-          So, generally, when not using the nix implementation,
-          you should always prefer to have `escapingFunction`
-          set to `lib.escapeShellArg`.
-
-          However, if you ARE using the `nix` implementation,
-          using `wlib.escapeShellArgWithEnv` will allow you
-          to use `$` expansions, which will expand at runtime.
-
-          `binary` implementation is useful for programs
-          which are likely to be used in "shebangs",
-          as macos will not allow scripts to be used for these.
-
-          However, it is more limited. It does not have access to
-          `runShell`, `prefixContent`, and `suffixContent` options.
-
-          Chosing `binary` will thus cause values in those options to be ignored.
-        '';
-      };
-      config.wrapperFunction = lib.mkDefault (self.wrapperFunction or (import ./.));
-      config.suffixVar =
+              Adds all its entries to the DAG under the name `NIX_LIB_ADDITIONS`
+            '';
+          };
+      config.${
+        if excluded.extraPackages or false && excluded.runtimeLibraries or false then "suffixVar" else null
+      } =
         lib.optional (config.extraPackages != [ ]) {
           name = "NIX_PATH_ADDITIONS";
           data = [
@@ -405,29 +325,354 @@
             "${lib.makeLibraryPath config.runtimeLibraries}"
           ];
         };
-      config.meta.maintainers = lib.mkDefault [ wlib.maintainers.birdee ];
-      config.meta.description = lib.mkDefault ''
-        An implementation of the `makeWrapper` interface via type safe module options.
+      options.${if !(excluded.env or false) then "env" else null} = lib.mkOption {
+        type = wlib.types.dagWithEsc wlib.types.stringable;
+        default = if mainConfig != null && config.mirror or false then mainConfig.env else { };
+        example = {
+          "XDG_DATA_HOME" = "/somewhere/on/your/machine";
+        };
+        description = ''
+          Environment variables to set in the wrapper.
 
-        Allows you to choose one of several underlying implementations of the `makeWrapper` interface.
+          This option takes a set.
 
-        Imported by `wlib.modules.default`
+          Any entry can instead be of type `{ data, before ? [], after ? [], esc-fn ? null }`
 
-        Wherever the type includes `DAG` you can mentally substitute this with `attrsOf`
+          This will cause it to be added to the DAG,
+          which will cause the resulting wrapper argument to be sorted accordingly
+        '';
+      };
+      options.${if !(excluded.envDefault or false) then "envDefault" else null} = lib.mkOption {
+        type = wlib.types.dagWithEsc wlib.types.stringable;
+        default = if mainConfig != null && config.mirror or false then mainConfig.envDefault else { };
+        example = {
+          "XDG_DATA_HOME" = "/only/if/not/set";
+        };
+        description = ''
+          Environment variables to set in the wrapper.
 
-        Wherever the type includes `DAL` or `DAG list` you can mentally substitute this with `listOf`
+          Like env, but only adds the variable if not already set in the environment.
 
-        However they also take items of the form `{ data, name ? null, before ? [], after ? [] }`
+          This option takes a set.
 
-        This allows you to specify that values are added to the wrapper before or after another value.
+          Any entry can instead be of type `{ data, before ? [], after ? [], esc-fn ? null }`
 
-        The sorting occurs across ALL the options, thus you can target items in any `DAG` or `DAL` within this module from any other `DAG` or `DAL` option within this module.
+          This will cause it to be added to the DAG,
+          which will cause the resulting wrapper argument to be sorted accordingly
+        '';
+      };
+      options.${if !(excluded.escapingFunction or false) then "escapingFunction" else null} =
+        lib.mkOption
+          {
+            type = lib.types.functionTo lib.types.str;
+            default =
+              if mainConfig != null && config.mirror or false then
+                mainConfig.escapingFunction
+              else
+                lib.escapeShellArg;
+            defaultText = "lib.escapeShellArg";
+            description = ''
+              The function to use to escape shell values
 
-        The `DAG`/`DAL` entries in this module also accept an extra field, `esc-fn ? null`
+              Caution: When using `shell` or `binary` implementations,
+              these will be expanded at BUILD time.
 
-        If defined, it will be used instead of the value of `options.escapingFunction` to escape that value.
+              You should probably leave this as is when using either of those implementations.
 
-        ---
-      '';
+              However, when using the `nix` implementation, they will expand at runtime!
+              Which means `wlib.escapeShellArgWithEnv` may prove to be a useful substitute!
+            '';
+          };
+      options.${if !(excluded.wrapperImplementation or false) then "wrapperImplementation" else null} =
+        lib.mkOption
+          {
+            type = lib.types.enum [
+              "nix"
+              "shell"
+              "binary"
+            ];
+            default =
+              if mainConfig != null && config.mirror or false then mainConfig.wrapperImplementation else "nix";
+            description = ''
+              the `nix` implementation is the default
+
+              It makes the `escapingFunction` most relevant.
+
+              This is because the `shell` and `binary` implementations
+              use `pkgs.makeWrapper` or `pkgs.makeBinaryWrapper`,
+              and arguments to these functions are passed at BUILD time.
+
+              So, generally, when not using the nix implementation,
+              you should always prefer to have `escapingFunction`
+              set to `lib.escapeShellArg`.
+
+              However, if you ARE using the `nix` implementation,
+              using `wlib.escapeShellArgWithEnv` will allow you
+              to use `$` expansions, which will expand at runtime.
+
+              `binary` implementation is useful for programs
+              which are likely to be used in "shebangs",
+              as macos will not allow scripts to be used for these.
+
+              However, it is more limited. It does not have access to
+              `runShell`, `prefixContent`, and `suffixContent` options.
+
+              Chosing `binary` will thus cause values in those options to be ignored.
+            '';
+          };
+      config._module.args = {
+        mainConfig = null;
+        mainOpts = null;
+      };
+      options.${if !(excluded.wrapperVariants or false) && is_top then "wrapperVariants" else null} =
+        lib.mkOption
+          {
+            default = { };
+            description = ''
+              Allows for you to apply the wrapper options to multiple binaries from config.package (or elsewhere)
+
+              They are called variants because they are the same options as the top level makeWrapper options,
+              however, their defaults mirror the values of the top level options.
+
+              Meaning if you set `config.env.MYVAR = "HELLO"` at the top level,
+              then the following statement would be true by default:
+
+              `config.wrapperVariants.foo.env.MYVAR.data == "HELLO"`
+
+              They achieve this by receiving `mainConfig` and `mainOpts` via `specialArgs`,
+              which contain `config` and `options` from the top level.
+            '';
+            type = lib.types.attrsOf (
+              lib.types.submoduleWith {
+                specialArgs = {
+                  mainConfig = config;
+                  mainOpts = options;
+                  inherit wlib;
+                };
+                modules = [
+                  (options_module excluded false)
+                  (
+                    { name, ... }:
+                    {
+                      options.enable = lib.mkOption {
+                        type = lib.types.bool;
+                        default = true;
+                        description = ''
+                          Enables the wrapping of this variant
+                        '';
+                      };
+                      options.mirror = lib.mkOption {
+                        type = lib.types.bool;
+                        default = true;
+                        description = ''
+                          Allows the variant to inherit defaults from the top level
+                        '';
+                      };
+                      options.exePath = lib.mkOption {
+                        type = lib.types.nullOr wlib.types.nonEmptyLine;
+                        default = "bin/${name}";
+                        description = ''
+                          The location within the package of the thing to wrap.
+                        '';
+                      };
+                      options.binName = lib.mkOption {
+                        type = wlib.types.nonEmptyLine;
+                        default = name;
+                        description = ''
+                          The name of the file to output to `$out/bin/`
+                        '';
+                      };
+                      options.package = lib.mkOption {
+                        type = wlib.types.stringable;
+                        default = config.package;
+                        description = ''
+                          The package to wrap with these options
+                        '';
+                      };
+                    }
+                  )
+                ];
+              }
+            );
+          };
+    };
+  usage_err = name: ''
+    ERROR: usage of ${name} is as follows:
+
+    (import wlib.modules.makeWrapper).${name} {
+      inherit config wlib;
+      inherit (pkgs) callPackage; # or `inherit pkgs`;${
+        if name != "wrapVariant" then "" else "\n  name = \"attribute\";\n"
+      }
+    };${
+      if name != "wrapVariant" then
+        ""
+      else
+        "\n\nWhere `attribute` is a valid attribute of the `config.wrapperVariants` set"
+    }
+  '';
+in
+{
+  wrapperFunction = import ./. null;
+
+  wrapAll =
+    {
+      pkgs ? null,
+      wlib,
+      callPackage ? pkgs.callPackage or (usage_err "wrapAll"),
+      config,
+    }:
+    callPackage (import ./. null) { inherit config wlib; };
+  wrapMain =
+    {
+      pkgs ? null,
+      wlib,
+      callPackage ? pkgs.callPackage or (usage_err "wrapMain"),
+      config,
+    }:
+    callPackage (import ./. false) { inherit config wlib; };
+  wrapVariants =
+    {
+      pkgs ? null,
+      wlib,
+      callPackage ? pkgs.callPackage or (usage_err "wrapVariants"),
+      config,
+    }:
+    callPackage (import ./. true) { inherit config wlib; };
+  wrapVariant =
+    {
+      pkgs ? null,
+      wlib,
+      callPackage ? pkgs.callPackage or (usage_err "wrapVariant"),
+      config,
+      name,
+    }:
+    assert builtins.isString name || usage_err "wrapVariant";
+    callPackage (import ./. name) { inherit config wlib; };
+
+  excluded_options = { };
+  exclude_wrapper = false;
+  exclude_meta = false;
+  __functor =
+    self:
+    {
+      wlib,
+      lib,
+      ...
+    }:
+    {
+      _file = ./module.nix;
+      key = ./module.nix;
+      imports = [ (options_module (self.excluded_options or { }) true) ];
+      config.${if self.exclude_wrapper or false then null else "wrapperFunction"} = lib.mkDefault (
+        self.wrapperFunction or (import ./. null)
+      );
+      config.${if self.exclude_meta or false then null else "meta"} = {
+        maintainers = lib.mkDefault [ wlib.maintainers.birdee ];
+        description = lib.mkDefault {
+          pre = ''
+            An implementation of the `makeWrapper` interface via type safe module options.
+
+            Allows you to choose one of several underlying implementations of the `makeWrapper` interface.
+
+            Imported by `wlib.modules.default`
+
+            Wherever the type includes `DAG` you can mentally substitute this with `attrsOf`
+
+            Wherever the type includes `DAL` or `DAG list` you can mentally substitute this with `listOf`
+
+            However they also take items of the form `{ data, name ? null, before ? [], after ? [] }`
+
+            This allows you to specify that values are added to the wrapper before or after another value.
+
+            The sorting occurs across ALL the options, thus you can target items in any `DAG` or `DAL` within this module from any other `DAG` or `DAL` option within this module.
+
+            The `DAG`/`DAL` entries in this module also accept an extra field, `esc-fn ? null`
+
+            If defined, it will be used instead of the value of `options.escapingFunction` to escape that value.
+
+            It also has a set of submodule options under `config.wrapperVariants` which allow you
+            to duplicate the effects to other binaries from the package, or add extra ones.
+
+            Each one contains an `enable` option, and a `mirror` option.
+
+            They also contain the same options the top level module does, however if `mirror` is `true`,
+            as it is by default, then they will inherit the defaults from the top level as well.
+
+            They also have their own `package`, `exePath`, and `binName` options, with sensible defaults.
+
+            ---
+          '';
+          post = ''
+            ---
+
+            ## The `makeWrapper` library:
+
+            Should you ever need to redefine `config.wrapperFunction`, or use these options somewhere else,
+            this module doubles as a library for doing so!
+
+            `makeWrapper = import wlib.modules.makeWrapper;`
+
+            If you import it like shown, you gain access to some values.
+
+            First, you may modify the module itself.
+
+            For this it offers:
+
+            `exclude_wrapper = true;` to stop it from setting `config.wrapperFunction`
+
+            `wrapperFunction = ...;` to override the default `config.wrapperFunction` that it sets instead of excluding it.
+
+            `exclude_meta = true;` to stop it from setting any values in `config.meta`
+
+            `excluded_options = { ... };` where you may include `optionname = true`
+            in order to not define that option.
+
+            In order to change these values, you change them in the set before importing the module like so:
+
+            ```nix
+              imports = [ (import wlib.modules.makeWrapper // { excluded_options.wrapperVariants = true; }) ];
+            ```
+
+            It also offers 4 functions for using those options to generate build instructions for a wrapper
+
+            - `wrapAll`: generates build instructions for the main target and all variants
+            - `wrapMain`: generates build instructions for the main target
+            - `wrapVariants`: generates build instructions for all variants but not the main target
+            - `wrapVariant`: generates build instructions for a single variant
+
+            All 4 of them return a string that can be added to the derivation definition to build the specified wrappers.
+
+            The first 3, `wrapAll`, `wrapMain`, and `wrapVariants`, are used like this:
+
+            (import wlib.modules.makeWrapper).wrapAll {
+              inherit config wlib;
+              inherit (pkgs) callPackage; # or `inherit pkgs`;
+            };
+
+            The 4th, `wrapVariant`, has an extra `name` argument:
+
+            (import wlib.modules.makeWrapper).wrapVariant {
+              inherit config wlib;
+              inherit (pkgs) callPackage; # or `inherit pkgs`;
+              name = \"attribute\";
+            };
+
+            Where `attribute` is an attribute of the `config.wrapperVariants` set
+
+            Other than whatever options from the `wlib.modules.makeWrapper` module
+            are defined in the `config` variable passed,
+            each one relies on `config` containing `binName`, `package`, and `exePath`.
+
+            If `config.exePath` is not a string or is an empty string,
+            `config.package` will be the full path wrapped.
+            Otherwise, it will wrap `"''${config.package}/''${config.binName}`.
+
+            If `config.binName` or `config.package` are not provided it will return an empty string for that target.
+
+            In addition, if a variant has `enable` set to `false`, it will also not be included in the returned string.
+          '';
+        };
+      };
     };
 }

--- a/wrapperModules/a/atool/module.nix
+++ b/wrapperModules/a/atool/module.nix
@@ -175,38 +175,14 @@
     # which one to run by the program basename. When atool is wrapped, the wrapper
     # script executes the original atool such that the basename is always atool, which
     # breaks these shortcuts. In order to keep these shortcuts functional, we wrap each one
-    drv.buildPhase =
-      let
-        binNames = [
-          "acat"
-          "adiff"
-          "als"
-          "apack"
-          "arepack"
-          "aunpack"
-        ];
-      in
-      "runHook preBuild\n"
-      + lib.pipe binNames [
-        (map (n: "$out/bin/${n}"))
-        (builtins.concatStringsSep " ")
-        (s: "rm " + s + "\n")
-      ]
-      + lib.pipe binNames [
-        (map (
-          n:
-          pkgs.callPackage config.wrapperFunction {
-            inherit wlib;
-            config = config // {
-              exePath = "bin/${n}";
-              binName = n;
-            };
-          }
-        ))
-        (builtins.concatStringsSep "\n")
-      ]
-      + "\nrunHook postBuild";
-
+    wrapperVariants = {
+      acat = { };
+      adiff = { };
+      als = { };
+      apack = { };
+      arepack = { };
+      aunpack = { };
+    };
     meta.maintainers = [ wlib.maintainers.jomarm ];
   };
 }

--- a/wrapperModules/n/neovim/makeWrapper/default.nix
+++ b/wrapperModules/n/neovim/makeWrapper/default.nix
@@ -2,6 +2,7 @@
   config,
   callPackage,
   lib,
+  wlib,
   luajit,
   ...
 }@args:
@@ -11,10 +12,13 @@ let
       lib.optionalString (config.settings.compile_generated_lua or false != "debug") ", true"
     }))' "
   }";
+  wrapNvim = callPackage (
+    if config.wrapperImplementation or "nix" == "nix" then
+      (import ./makeWrapperNix.nix maybe_compile)
+    else
+      (import ./makeWrapper.nix maybe_compile)
+  ) args;
 in
-callPackage (
-  if config.wrapperImplementation or "nix" == "nix" then
-    (import ./makeWrapperNix.nix maybe_compile)
-  else
-    (import ./makeWrapper.nix maybe_compile)
-) args
+wrapNvim
++ "\n"
++ (import wlib.modules.makeWrapper).wrapVariants { inherit config wlib callPackage; }

--- a/wrapperModules/n/neovim/packDir.nix
+++ b/wrapperModules/n/neovim/packDir.nix
@@ -51,9 +51,10 @@ let
             if v ? config then
               acc
               ++ [
-                (pkgs.callPackage (import wlib.modules.makeWrapper).wrapperFunction {
+                ((import wlib.modules.makeWrapper).wrapMain {
                   inherit wlib;
                   inherit (v) config;
+                  inherit (pkgs) callPackage;
                 })
               ]
             else if v ? bin_path then

--- a/wrapperModules/n/neovim/post_desc.md
+++ b/wrapperModules/n/neovim/post_desc.md
@@ -292,3 +292,21 @@ local value = nixInfo(default, "path", "to", "value", "in", "plugin")
   };
 }
 ```
+
+---
+
+## NOTE: `wrapperVariants`:
+
+In this module, `config.wrapperVariants` behaves slightly differently.
+
+If you use it, your package is not guaranteed to be compatible with multiple installs.
+
+The `config.wrapperVariants.<name>.package` field defaults to `pkgs.<name>` if not set.
+
+The `config.wrapperVariants.<name>.mirror` field is false and cannot be set to true.
+
+Use it if you need to wrap an extra package in the context of your neovim derivation,
+but `config.hosts` was not suitable for the task.
+
+Again, use of this option is very likely to cause path collisions with
+multiple simultaneous installations.


### PR DESCRIPTION
options for wrapping multiple binaries from the same package (or more than 1)

Addresses issue:

https://github.com/BirdeeHub/nix-wrapper-modules/issues/233

`config.exePath` can now be null for derivations which are not directories.

This makes `atool` wrapping a bunch of items with the same options look like:

```nix
    wrapperVariants = {
      acat = { };
      adiff = { };
      als = { };
      apack = { };
      arepack = { };
      aunpack = { };
    };
```

But allows much more flexibility than just simply applying the same exact options.