### PR TITLE
fix(docs): remove extra mkDefault, lib.literalExpression

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -119,7 +119,7 @@ let
     };
 in
 {
-  config.meta.description = lib.mkOverride 1499 ''
+  config.meta.description = ''
     # Core (builtin) Options set
 
     These are the core options that make everything else possible.
@@ -144,7 +144,7 @@ in
 
     ---
   '';
-  config.meta.maintainers = lib.mkOverride 1499 [ wlib.maintainers.birdee ];
+  config.meta.maintainers = [ wlib.maintainers.birdee ];
   config._module.args.pkgs = config.pkgs;
   options = {
     meta = {
@@ -162,7 +162,7 @@ in
           "aarch64-linux"
         ];
         default = lib.platforms.all;
-        defaultText = "lib.platforms.all";
+        defaultText = lib.literalExpression "lib.platforms.all";
         description = "Supported platforms";
       };
       description = lib.mkOption {
@@ -178,6 +178,7 @@ in
       };
     };
     pkgs = lib.mkOption {
+      type = lib.types.pkgs;
       description = ''
         The nixpkgs pkgs instance to use.
 
@@ -639,7 +640,7 @@ in
               runHook postInstall
             '';
           }
-          // builtins.removeAttrs config.drv [
+          // removeAttrs config.drv [
             "passthru"
             "buildCommand"
             "outputs"

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -201,6 +201,7 @@ in
             (lib.toList value)
             ++ [
               {
+                _file = ./lib.nix;
                 config.pkgs = lib.mkIf (pkgs != null) pkgs;
                 options.enable = lib.mkEnableOption name;
               }

--- a/modules/default/module.nix
+++ b/modules/default/module.nix
@@ -4,7 +4,7 @@
     wlib.modules.symlinkScript
     wlib.modules.makeWrapper
   ];
-  config.meta.description = lib.mkDefault ''
+  config.meta.description = ''
     This module imports both `wlib.modules.makeWrapper` and `wlib.modules.symlinkScript` for convenience
 
     ## `wlib.modules.makeWrapper`
@@ -33,5 +33,5 @@
 
     ---
   '';
-  config.meta.maintainers = lib.mkDefault [ wlib.maintainers.birdee ];
+  config.meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -106,18 +106,22 @@ let
       options.${if !(excluded.addFlag or false) then "addFlag" else null} = lib.mkOption {
         type = wlib.types.wrapperFlag;
         default = if mainConfig != null && config.mirror or false then mainConfig.addFlag else [ ];
-        example = [
-          "-v"
-          "-f"
+        example = lib.literalMD ''
+          ```nix
           [
-            "--config"
-            "\${./storePath.cfg}"
+            "-v"
+            "-f"
+            [
+              "--config"
+              ./storePath.cfg
+            ]
+            [
+              "-s"
+              "idk"
+            ]
           ]
-          [
-            "-s"
-            "idk"
-          ]
-        ];
+          ```
+        '';
         description = ''
           Wrapper for
 
@@ -139,18 +143,22 @@ let
       options.${if !(excluded.appendFlag or false) then "appendFlag" else null} = lib.mkOption {
         type = wlib.types.wrapperFlag;
         default = if mainConfig != null && config.mirror or false then mainConfig.appendFlag else [ ];
-        example = [
-          "-v"
-          "-f"
+        example = lib.literalMD ''
+          ```nix
           [
-            "--config"
-            "\${./storePath.cfg}"
+            "-v"
+            "-f"
+            [
+              "--config"
+              ./storePath.cfg
+            ]
+            [
+              "-s"
+              "idk"
+            ]
           ]
-          [
-            "-s"
-            "idk"
-          ]
-        ];
+          ```
+        '';
         description = ''
           --append-flag ARG
 
@@ -170,18 +178,22 @@ let
       options.${if !(excluded.prefixVar or false) then "prefixVar" else null} = lib.mkOption {
         type = wlib.types.wrapperFlags 3;
         default = if mainConfig != null && config.mirror or false then mainConfig.prefixVar else [ ];
-        example = [
+        example = lib.literalMD ''
+          ```nix
           [
-            "LD_LIBRARY_PATH"
-            ":"
-            "\${lib.makeLibraryPath (with pkgs; [ ... ])}"
+            [
+              "LD_LIBRARY_PATH"
+              ":"
+              "''${lib.makeLibraryPath (with pkgs; [ ... ])}"
+            ]
+            [
+              "PATH"
+              ":"
+              "''${lib.makeBinPath (with pkgs; [ ... ])}"
+            ]
           ]
-          [
-            "PATH"
-            ":"
-            "\${lib.makeBinPath (with pkgs; [ ... ])}"
-          ]
-        ];
+          ```
+        '';
         description = ''
           --prefix ENV SEP VAL
 
@@ -191,18 +203,22 @@ let
       options.${if !(excluded.suffixVar or false) then "suffixVar" else null} = lib.mkOption {
         type = wlib.types.wrapperFlags 3;
         default = if mainConfig != null && config.mirror or false then mainConfig.suffixVar else [ ];
-        example = [
+        example = lib.literalMD ''
+          ```nix
           [
-            "LD_LIBRARY_PATH"
-            ":"
-            "\${lib.makeLibraryPath (with pkgs; [ ... ])}"
+            [
+              "LD_LIBRARY_PATH"
+              ":"
+              "''${lib.makeLibraryPath (with pkgs; [ ... ])}"
+            ]
+            [
+              "PATH"
+              ":"
+              "''${lib.makeBinPath (with pkgs; [ ... ])}"
+            ]
           ]
-          [
-            "PATH"
-            ":"
-            "\${lib.makeBinPath (with pkgs; [ ... ])}"
-          ]
-        ];
+          ```
+        '';
         description = ''
           --suffix ENV SEP VAL
 
@@ -256,9 +272,13 @@ let
       options.${if !(excluded.flags or false) then "flags" else null} = lib.mkOption {
         type = (import ./genArgsFromFlags.nix { inherit lib wlib; }).flagDag;
         default = if mainConfig != null && config.mirror or false then mainConfig.flags else { };
-        example = {
-          "--config" = "\${./nixPath}";
-        };
+        example = lib.literalMD ''
+          ```nix
+          {
+            "--config" = ./nixPath;
+          }
+          ```
+        '';
         description = ''
           Flags to pass to the wrapper.
           The key is the flag name, the value is the flag value.
@@ -370,7 +390,7 @@ let
                 mainConfig.escapingFunction
               else
                 lib.escapeShellArg;
-            defaultText = "lib.escapeShellArg";
+            defaultText = lib.literalExpression "lib.escapeShellArg";
             description = ''
               The function to use to escape shell values
 
@@ -568,8 +588,8 @@ in
         self.wrapperFunction or (import ./. null)
       );
       config.${if self.exclude_meta or false then null else "meta"} = {
-        maintainers = lib.mkDefault [ wlib.maintainers.birdee ];
-        description = lib.mkDefault {
+        maintainers = [ wlib.maintainers.birdee ];
+        description = {
           pre = ''
             An implementation of the `makeWrapper` interface via type safe module options.
 

--- a/modules/symlinkScript/module.nix
+++ b/modules/symlinkScript/module.nix
@@ -131,8 +131,8 @@
 
     ''
   );
-  config.meta.maintainers = lib.mkDefault [ wlib.maintainers.birdee ];
-  config.meta.description = lib.mkDefault ''
+  config.meta.maintainers = [ wlib.maintainers.birdee ];
+  config.meta.description = ''
     Adds extra options compared to the default `builderFunction` option value.
 
     Imported by `wlib.modules.default`

--- a/parts.nix
+++ b/parts.nix
@@ -98,7 +98,13 @@ in
             else
               lib.filterAttrs (n: _: !args ? "${n}") wrappers
           )
-          (builtins.mapAttrs (_: v: v.wrap { inherit (config.wrappers) pkgs; }))
+          (builtins.mapAttrs (
+            _: v:
+            v.wrap {
+              _file = file;
+              inherit (config.wrappers) pkgs;
+            }
+          ))
         ];
       }
     );


### PR DESCRIPTION
removed mkDefault from meta.maintainers and meta.description in the core and helper modules, as the values are already labelled by file and they are useful metadata for docgen

used lib.literalExpression and lib.literalMD to improve some examples and default value listings in the docs

Edit: I think `fix` was probably the wrong commit name, but its too late now I am not going to force push over main to change that.