### PR TITLE
ci(wrapperModules.mpv): guard against broken pipe in mpv test

### DIFF
--- a/wrapperModules/m/mpv/check.nix
+++ b/wrapperModules/m/mpv/check.nix
@@ -18,13 +18,13 @@ let
 in
 pkgs.runCommand "mpv-test" { } ''
   res="$(${mpvWrapped}/bin/mpv --version)"
-  if ! echo "$res" | grep -q "mpv"; then
+  if ! echo "$res" | grep "mpv"; then
     echo "failed to run wrapped package!"
     echo "wrapper content for ${mpvWrapped}/bin/mpv"
     cat "${mpvWrapped}/bin/mpv"
     exit 1
   fi
-  if ! cat "${mpvWrapped.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F -q "share/mpv/scripts/visualizer.lua"; then
+  if ! cat "${mpvWrapped.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F "share/mpv/scripts/visualizer.lua"; then
     echo "failed to find added script when inspecting overriden package value"
     echo "overriden package value ${mpvWrapped.configuration.package}/bin/mpv"
     cat "${mpvWrapped.configuration.package}/bin/mpv"


### PR DESCRIPTION
github really likes to fail grep -q whenever it feels like it.

I like -q because otherwise the output is even longer than it already is and doesn't have useful information. Grep doesnt show anything useful on failure. But I like not having random test failures more.