### PR TITLE
ci(tests-docs): remove warning

### DIFF
--- a/checks/meta-maintainers.nix
+++ b/checks/meta-maintainers.nix
@@ -24,8 +24,13 @@ pkgs.runCommand "meta-maintainers-test" { } ''
   echo "Testing meta.maintainers field with nixpkgs maintainer..."
 
   # Check that meta.maintainers is set correctly
-  maintainers='${builtins.toJSON moduleConfig.meta.maintainers}'
+  maintainers='${builtins.toJSON (map (v: removeAttrs v [ "file" ]) moduleConfig.meta.maintainers)}'
   echo "Maintainers: $maintainers"
+
+  if ${if builtins.all (v: v ? file) moduleConfig.meta.maintainers then "false" else "true"}; then
+    echo "FAIL: a meta.maintainers entry is missing a file field"
+    exit 1
+  fi
 
   # Verify the maintainer has all required fields
   if ! echo "$maintainers" | grep -q ${esc nixpkgsMaintainer.name}; then

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -79,7 +79,7 @@ in
   drv.core_docs = buildModuleDocs {
     package = pkgs.hello;
     title = "Core (builtin) Options set";
-  } "core" wlib.core;
+  } "core" { };
   books.nix-wrapper-modules = {
     book = {
       book = {
@@ -110,13 +110,13 @@ in
         name = "Getting Started";
         data = "numbered";
         path = "md/getting-started.md";
-        src = ./md/getting-started.md;
+        src = builtins.path { path = ./md/getting-started.md; };
       }
       {
         name = "Lib Functions";
         data = "numbered";
         path = "md/lib-intro.md";
-        src = ./md/lib-intro.md;
+        src = builtins.path { path = ./md/lib-intro.md; };
         subchapters = [
           {
             name = "wlib";
@@ -166,7 +166,7 @@ in
         name = "Helper Modules";
         data = "numbered";
         path = "md/helper-modules.md";
-        src = ./md/helper-modules.md;
+        src = builtins.path { path = ./md/helper-modules.md; };
         subchapters = lib.mapAttrsToList (n: _: {
           name = n;
           data = "numbered";
@@ -178,7 +178,7 @@ in
         name = "Wrapper Modules";
         data = "numbered";
         path = "md/wrapper-modules.md";
-        src = ./md/wrapper-modules.md;
+        src = builtins.path { path = ./md/wrapper-modules.md; };
         subchapters = lib.mapAttrsToList (n: _: {
           name = n;
           data = "numbered";


### PR DESCRIPTION
builtins.path in docgen to make sure it actually knows what repository it is in despite discarded context.

Also stop it from writing the files of maintainers into the meta-maintainers-test derivation, for the same reason, the values you get for file during type merging have discarded context.