### PR TITLE
fix(modules.makeWrapper): binary implementation

### DIFF
--- a/modules/makeWrapper/makeWrapper.nix
+++ b/modules/makeWrapper/makeWrapper.nix
@@ -138,10 +138,12 @@ then
 else
   ''
     (
+      OLD_OPTS="$(set +o)"
       ${srcsetup dieHook}
       ${srcsetup (
         if config.wrapperImplementation or null == "shell" then makeWrapper else makeBinaryWrapper
       )}
+      eval "$OLD_OPTS"
       makeWrapper ${baseArgs} ${builtins.concatStringsSep " " resArgs}
     )
   ''

--- a/wrapperModules/n/neovim/makeWrapper/makeWrapper.nix
+++ b/wrapperModules/n/neovim/makeWrapper/makeWrapper.nix
@@ -192,8 +192,10 @@ if config.binName == "" then
 else
   /* bash */ ''
     (
+      OLD_OPTS="$(set +o)"
       ${srcsetup dieHook}
       ${srcsetup (if config.wrapperImplementation == "binary" then makeBinaryWrapper else makeWrapper)}
+      eval "$OLD_OPTS"
       mkdir -p $out/bin
       { [ -e "$manifestLuaPath" ] && cat "$manifestLuaPath" || echo "$manifestLua"; } > ${lib.escapeShellArg luarc-path}
       export NVIM_RPLUGIN_MANIFEST=${manifest-path}


### PR DESCRIPTION
binary implementation sets opts that would normally be reset by later stdenv stages but in this case are not. Manually reset shell opts.