### PR TITLE
fix(lib.types.stringable): ensures store paths are realized

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -305,7 +305,12 @@
     descriptionClass = "noun";
     description = "str|path|drv";
     check = lib.isStringLike;
-    merge = lib.mergeEqualOption;
+    merge =
+      loc: defs:
+      let
+        res = lib.mergeEqualOption loc defs;
+      in
+      if builtins.isPath res then builtins.path { path = res; } else res;
   };
 
   /**


### PR DESCRIPTION
sometimes passing a regular nix store path like `./somepath` will not get realized unless you call `builtins.path { path = ./somedir; }`

When a user uses a type like this, and provides a store path to it, they expect it to be provisioned. It is also safe to call multiple times on a value. So we should handle this in this type.