### PR TITLE
fix(wrapperModules.nushell): make it work in mac shebangs

### DIFF
--- a/wrapperModules/n/nushell/module.nix
+++ b/wrapperModules/n/nushell/module.nix
@@ -38,6 +38,8 @@
     "--env-config" = config."env.nu".path;
   };
 
+  config.wrapperImplementation = "binary";
+
   config.package = lib.mkDefault pkgs.nushell;
 
   config.meta.maintainers = [ wlib.maintainers.birdee ];


### PR DESCRIPTION
`wrapperImplementation = "binary"` to use `pkgs.makeBinaryWrapper` as the backend.

This is not really for speed, it is about the same in terms of speed as they are short wrappers that deal mostly with literal strings and then transfer control to another process.

You also get less control over how stuff is escaped in the final result, as the binary cannot run shell code, and any variable expansion allowed (by default not possible as it uses lib.escapeShellArg by default) will happen at build time

However on mac shebangs need to be binaries. This is important for shells and other things which are used in shebangs.