### PR TITLE
fix(wrapperModules.nushell): set passthru.shellPath

### DIFF
--- a/wrapperModules/n/nushell/module.nix
+++ b/wrapperModules/n/nushell/module.nix
@@ -37,6 +37,7 @@
     "--config" = config."config.nu".path;
     "--env-config" = config."env.nu".path;
   };
+  config.passthru.shellPath = "/bin/nu";
 
   config.wrapperImplementation = "binary";
 


### PR DESCRIPTION
shells need that if you want to pass them to environment.shells or other such nixos options for shells.