### PR TITLE
feat(core.outputName): full multi-output support

### DIFF
--- a/ci/checks/outputName-tests.nix
+++ b/ci/checks/outputName-tests.nix
@@ -1,0 +1,64 @@
+{
+  pkgs,
+  self,
+}:
+
+let
+  inherit (pkgs) runCommand;
+  inherit (self.lib) wrapPackage;
+
+  # Test with custom outputName
+  wrapped-custom-out = wrapPackage {
+    inherit pkgs;
+    package = pkgs.hello;
+    # NOTE: It should detect that myout is not present and add it
+    # outputs = [
+    #   "out"
+    #   "myout"
+    # ];
+    outputName = "myout";
+  };
+
+  # Test with custom binDir
+  wrapped-custom-binDir = wrapPackage {
+    inherit pkgs;
+    package = pkgs.hello;
+    binDir = "sbin";
+  };
+
+  # # Test with binDir = null (no subdirectory)
+  wrapped-null-binDir = wrapPackage {
+    inherit pkgs;
+    package = pkgs.hello;
+    binDir = null;
+  };
+
+in
+
+runCommand "outputName-tests" { } ''
+  # Test custom outputName
+  if [ ! -f "${wrapped-custom-out.myout}/bin/hello" ]; then
+    echo "FAIL: Expected wrapper at ${wrapped-custom-out.myout}/bin/hello"
+    echo "Contents of ${wrapped-custom-out.myout}:"
+    ls -laR "${wrapped-custom-out.myout}"
+    exit 1
+  fi
+
+  # Test custom binDir
+  if [ ! -f "${wrapped-custom-binDir}/sbin/hello" ]; then
+    echo "FAIL: Expected wrapper at ${wrapped-custom-binDir}/sbin/hello"
+    echo "Contents of ${wrapped-custom-binDir}:"
+    ls -laR "${wrapped-custom-binDir}"
+    exit 1
+  fi
+
+  # Test binDir = null (no subdirectory)
+  echo "Testing binDir = null..."
+  if [ ! -f "${wrapped-null-binDir}/hello" ]; then
+    echo "FAIL: Expected binary at ${wrapped-null-binDir}/hello"
+    echo "Contents of ${wrapped-null-binDir}:"
+    ls -la "${wrapped-null-binDir}/"
+    exit 1
+  fi
+  touch $out
+''

--- a/ci/flake.nix
+++ b/ci/flake.nix
@@ -62,7 +62,7 @@
         docs = wlib.evalPackage [
           ./docs
           {
-            warningsAreErrors = false;
+            warningsAreErrors = lib.mkDefault false;
             pkgs = import nixpkgs {
               inherit system;
               config = {

--- a/lib/core.nix
+++ b/lib/core.nix
@@ -398,13 +398,22 @@ in
         and `config.sourceStdenv` options.
       '';
     };
+    binDir = lib.mkOption {
+      type = lib.types.nullOr wlib.types.nonEmptyLine;
+      default = "bin";
+      description = ''
+        the directory the wrapped result will be placed into, with the name indicated by the `binName` option
+
+        i.e. `"''${placeholder outputName}/<THIS_VALUE>/''${binName}"`
+      '';
+    };
     binName = lib.mkOption {
-      type = wlib.types.nonEmptyLine;
+      type = lib.types.str;
       default =
         if config.package.meta.mainProgram or null != null then
           baseNameOf (
             builtins.addErrorContext ''
-              `config.package`: ${config.package} is not a derivation.
+              `config.package`: ${config.package} is not a derivation with a main executable.
               You must specify `config.binName` manually.
             '' (lib.getExe config.package)
           )
@@ -414,7 +423,7 @@ in
           config.package.pname or config.package.name
             or (throw "config.binName was not able to be detected!");
       description = ''
-        The name of the binary output by `wrapperFunction` to `$out/bin`
+        The name of the binary output by `wrapperFunction` to `config.wrapperPaths.placeholder`
 
         If not specified, the default name from the package will be used.
       '';
@@ -426,21 +435,77 @@ in
           lib.removePrefix "/" (
             lib.removePrefix "${config.package}" (
               builtins.addErrorContext ''
-                `config.package`: ${config.package} is not a derivation.
+                `config.package`: ${config.package} is not a derivation with a main executable.
                 You must specify `config.exePath` manually.
               '' (lib.getExe config.package)
             )
           )
         else if builtins.isString config.package || builtins.isPath config.package then
-          "bin/${baseNameOf (toString config.package)}"
+          lib.optionalString (config.binDir != null) "${config.binDir}/"
+          + "${baseNameOf (toString config.package)}"
         else
-          "bin/${
-            config.package.pname or config.package.name or (throw "config.binName was not able to be detected!")
+          lib.optionalString (config.binDir != null) "${config.binDir}/"
+          + "${config.package.pname or config.package.name
+            or (throw "config.binName was not able to be detected! Please specify it manually!")
           }";
       description = ''
         The relative path to the executable to wrap. i.e. `bin/exename`
 
         If not specified, the path gained from calling `lib.getExe` on `config.package` and subtracting the path to the package will be used.
+      '';
+    };
+    wrapperPaths = {
+      input = lib.mkOption {
+        type = lib.types.str;
+        readOnly = true;
+        default = "${config.package}" + lib.optionalString (config.exePath != null) "/${config.exePath}";
+        description = "The path which is to be wrapped by the wrapperFunction implementation";
+      };
+      placeholder = lib.mkOption {
+        type = lib.types.str;
+        readOnly = true;
+        default = "${placeholder config.outputName}${config.wrapperPaths.relPath}";
+        description = "The path which the wrapperFunction implementation is to output its result to.";
+      };
+      relPath = lib.mkOption {
+        type = lib.types.str;
+        readOnly = true;
+        default =
+          config.wrapperPaths.relDir + lib.optionalString (config.binName or "" != "") "/${config.binName}";
+        description = ''
+          The binary will be output to `''${placeholder config.outputName}''${config.wrapperPaths.relPath}`
+        '';
+      };
+      relDir = lib.mkOption {
+        type = lib.types.str;
+        readOnly = true;
+        default = lib.optionalString (config.binDir != null) "/${config.binDir}";
+        description = ''
+          The binary will be output to `''${placeholder config.outputName}''${config.wrapperPaths.relDir}/''${config.binName}`
+        '';
+      };
+    };
+    outputName = lib.mkOption {
+      type = wlib.types.nonEmptyLine;
+      default =
+        config.package.outputName or (
+          if builtins.length (config.package.outputs or [ ]) > 0 then
+            builtins.head config.package.outputs
+          else
+            "out"
+        );
+      description = ''
+        The derivation output the wrapped binary will be placed into.
+
+        This will also set the default output of the derivation.
+
+        This means, it will be first in `config.outputs`, and
+        the final drv will contain an `outputName` attribute with this name.
+
+        Unfortunately, `nix build` will still build `out` by default.
+        If you use this, know why you are doing so.
+
+        This is primarily for wrapping packages which already have a non-standard default output name.
       '';
     };
     outputs = lib.mkOption rec {
@@ -449,11 +514,16 @@ in
           base = lib.types.addCheck (lib.types.listOf lib.types.str) (v: builtins.length v > 0);
         in
         base // { description = "non-empty " + base.description or "listOf str"; };
-      default = if type.check config.package.outputs then config.package.outputs else [ "out" ];
+      default = if type.check (config.package.outputs or [ ]) then config.package.outputs else [ "out" ];
+      apply = v: [ config.outputName ] ++ lib.remove config.outputName v;
       description = ''
         Override the list of nix outputs that get symlinked into the final package.
 
-        Default is config.package.outputs or `[ "out" ]` if invalid.
+        Default is `config.package.outputs` or `[ "out" ]` if invalid.
+
+        `config.outputName` will always be the first item of the resulting list in `config.outputs`
+
+        It is added via the apply field of the option for you.
       '';
     };
     wrapperFunction = lib.mkOption {
@@ -476,9 +546,17 @@ in
 
         The result of this function is passed DIRECTLY to the value of the `builderFunction` function.
 
-        The relative path to the thing to wrap from within `config.package` is `config.exePath`
+        The relative path to the thing to wrap is `config.wrapperPaths.input`
 
-        You should wrap the package and place the wrapper at `"$out/bin/''${config.binName}"`
+        This function is to return a value which creates a result at `config.wrapperPaths.placeholder`
+
+        The type this value is to return is dictated by `config.builderFunction`.
+
+        The default implementation, as well as the implementation from `wlib.modules.symlinkScript`
+        accept either a string which will be prepended to `buildCommand` (preferred),
+        or a derivation which can be symlinked into the resulting derivation output to create the desired path.
+
+        Again, the result is passed DIRECTLY as an argument to the function which is the value of `config.builderFunction`
       '';
     };
     builderFunction = lib.mkOption {
@@ -574,22 +652,28 @@ in
           ...
         }:
         let
-          path = if wrapper != null then wrapper else config.package;
           originalOutputs = wlib.getPackageOutputsSet config.package;
         in
-        "mkdir -p $out \n"
-        + (if builtins.isString wrapper then wrapper else "${lndir}/bin/lndir -silent \"${path}\" $out")
+        "mkdir -p ${placeholder config.outputName} \n"
+        + (
+          if builtins.isString wrapper then
+            wrapper
+          else if wrapper != null then
+            "${lndir}/bin/lndir -silent \"${toString wrapper}\" ${placeholder config.outputName}"
+          else
+            ""
+        )
         + ''
 
           # Handle additional outputs by symlinking from the original package's outputs
           ${lib.concatMapStringsSep "\n" (
             output:
-            if output != "out" && originalOutputs ? ${output} && originalOutputs.${output} != null then
+            if originalOutputs ? ${output} && originalOutputs.${output} != null then
               ''
                 if [[ -n "''${${output}:-}" ]]; then
-                  mkdir -p ${"$" + output}
+                  mkdir -p ${placeholder output}
                   # Only symlink from the original package's corresponding output
-                  ${lndir}/bin/lndir -silent "${originalOutputs.${output}}" ${"$" + output}
+                  ${lndir}/bin/lndir -silent "${originalOutputs.${output}}" ${placeholder output}
                 fi
               ''
             else
@@ -627,7 +711,12 @@ in
             package
             binName
             ;
-          meta = (package.meta or { }) // { mainProgram = binName; } // (config.drv.meta or { });
+          meta =
+            (package.meta or { })
+            // {
+              ${if config.binDir == "bin" && binName != "" then "mainProgram" else null} = binName;
+            }
+            // (config.drv.meta or { });
           version =
             package.version or meta.version or package.revision or meta.revision or package.rev or meta.rev
               or package.release or meta.release or package.releaseDate or meta.releaseDate or "master";
@@ -668,9 +757,16 @@ in
             dontPatch = true;
             dontFixup = true;
             name = package.name or "${package.pname or binName}-${version}";
-            pname = package.pname or binName;
+            ${
+              if builtins.isString (package.pname or binName) && package.pname or binName != "" then
+                "pname"
+              else
+                null
+            } =
+              package.pname or binName;
             inherit version meta;
             inherit (config) outputs;
+            outputName = config.outputName or "out";
             buildPhase = ''
               runHook preBuild
               runHook postBuild
@@ -686,7 +782,7 @@ in
             "outputs"
             "meta"
           ];
-          errormsg = "config.builderFunction function must return (a string) or (a function that recieves attrset and returns an attrset) or (a functor as described in https://birdeehub.github.io/nix-wrapper-modules/core.html#builderfunction)";
+          errormsg = "config.builderFunction function must return (a string) or (a function that receives attrset and returns an attrset) or (a functor as described in https://birdeehub.github.io/nix-wrapper-modules/core.html#builderfunction)";
           defaultPhases = [
             "unpackPhase"
             "patchPhase"

--- a/lib/makeWrapper/default.nix
+++ b/lib/makeWrapper/default.nix
@@ -84,25 +84,22 @@ in
       - `wrapperImplementation` (optional): Path or function for the wrapper implementation.
 
     Requirements on `config`:
-      - Must define `binName`, `package`, and `exePath`.
+      - Must define `wrapperPaths.input`, `wrapperPaths.placeholder`, `wrapperPaths.relDir`, `outputName`.
       - May include options from `wlib.modules.makeWrapper`.
 
     Behavior:
       - Wraps the main target and all enabled variants.
-      - If `config.binName` or `config.package` are missing, returns an empty string.
-      - If `config.exePath` is not a non-empty string, wraps the full `config.package` path.
-        Otherwise wraps:
-          `"${config.package}/${config.binName}"`
-      - Variants with `enable = false` are excluded.
-      - It will output the main wrapper to `${placeholder "out"}/${config.binDir or "bin"}/${config.binName}`
-      - It will do the same for each enabled variant, but with values from that variant's option set.
+      - Wraps the path at `config.wrapperPaths.input`
+      - Outputs it to `config.wrapperPaths.placeholder`
+      - Wraps the paths at `config.wrapperVariants.*.wrapperPaths.input`
+      - Outputs to `config.wrapperVariants.*.wrapperPaths.placeholder`
 
     Returns:
       A string containing build instructions to append to a derivation.
 
     It also takes as an argument `wrapperImplementation`
 
-    You may define a function that recieves `config`, `wlib`, and arguments from `callPackage`
+    You may define a function that receives `config`, `wlib`, and arguments from `callPackage`
     and returns a string of build instructions, that follows similar behavior.
 
     You may use the other functions in `wlib.makeWrapper` to help with this.
@@ -139,23 +136,20 @@ in
       - `wrapperImplementation` (optional): Path or function for the wrapper implementation.
 
     Requirements on `config`:
-      - Must define `binName`, `package`, and `exePath`.
+      - Must define `wrapperPaths.input`, `wrapperPaths.placeholder`, `wrapperPaths.relDir`, `outputName`.
       - May include options from `wlib.modules.makeWrapper`.
 
     Behavior:
       - Wraps only the main target (no variants).
-      - If `config.binName` or `config.package` are missing, returns an empty string.
-      - If `config.exePath` is not a non-empty string, wraps the full `config.package` path.
-        Otherwise wraps:
-          `"${config.package}/${config.binName}"`
-      - It will output the wrapper to `${placeholder "out"}/${config.binDir or "bin"}/${config.binName}`
+      - Wraps the path at `config.wrapperPaths.input`
+      - Outputs to `config.wrapperPaths.placeholder`
 
     Returns:
       A string containing build instructions to append to a derivation.
 
     It also takes as an argument `wrapperImplementation`
 
-    You may define a function that recieves `config`, `wlib`, and arguments from `callPackage`
+    You may define a function that receives `config`, `wlib`, and arguments from `callPackage`
     and returns a string of build instructions, that follows similar behavior.
 
     You may use the other functions in `wlib.makeWrapper` to help with this.
@@ -193,26 +187,22 @@ in
       - `wrapperImplementation` (optional): Path or function for the wrapper implementation.
 
     Requirements on `config`:
-      - Must define `binName`, `package`, and `exePath`.
+      - Must define `wrapperPaths.input`, `wrapperPaths.placeholder`, `wrapperPaths.relDir`, `outputName`.
       - Must define `wrapperVariants` as an attribute set.
       - May include options from `wlib.modules.makeWrapper`.
 
     Behavior:
       - Wraps all variants in `config.wrapperVariants`.
       - Variants with `enable = false` are excluded.
-      - If `config.binName` or `config.package` are missing, returns an empty string.
-      - If `config.exePath` is not a non-empty string, wraps the full `config.package` path.
-        Otherwise wraps:
-          `"${config.package}/${config.binName}"`
-      - It will output each variant to the `${placeholder "out"}/${config.binDir or "bin"}/${config.binName}`
-        corresponding to that variants options
+      - Wraps the paths at `config.wrapperVariants.*.wrapperPaths.input`
+      - Outputs to `config.wrapperVariants.*.wrapperPaths.placeholder`
 
     Returns:
       A string containing build instructions to append to a derivation.
 
     It also takes as an argument `wrapperImplementation`
 
-    You may define a function that recieves `config`, `wlib`, and arguments from `callPackage`
+    You may define a function that receives `config`, `wlib`, and arguments from `callPackage`
     and returns a string of build instructions, that follows similar behavior.
 
     You may use the other functions in `wlib.makeWrapper` to help with this.
@@ -252,27 +242,22 @@ in
         in `config.wrapperVariants`.
 
     Requirements on `config`:
-      - Must define `binName`, `package`, and `exePath`.
-      - Must define `wrapperVariants` containing `name`.
+      - Must define `wrapperPaths.input`, `wrapperPaths.placeholder`, `wrapperPaths.relDir`, `outputName`.
       - May include options from `wlib.modules.makeWrapper`.
 
     Behavior:
       - Wraps only the specified variant.
       - Asserts that `name` is a string.
       - If the selected variant has `enable = false`, it is excluded.
-      - If `config.binName` or `config.package` are missing, returns an empty string.
-      - If `config.exePath` is not a non-empty string, wraps the full `config.package` path.
-        Otherwise wraps:
-          `"${config.package}/${config.binName}"`
-      - It will output the wrapper to:
-        `"${placeholder "out"}/${config.wrapperVariants.${name}.binDir or "bin"}/${config.wrapperVariants.${name}.binName}"`
+      - Wraps the path at `config.wrapperVariants.${name}.wrapperPaths.input`
+      - Outputs to `config.wrapperVariants.${name}.wrapperPaths.placeholder`
 
     Returns:
       A string containing build instructions to append to a derivation.
 
     It also takes as an argument `wrapperImplementation`
 
-    You may define a function that recieves `config`, `wlib`, and arguments from `callPackage`
+    You may define a function that receives `config`, `wlib`, and arguments from `callPackage`
     and returns a string of build instructions, that follows similar behavior.
 
     You may use the other functions in `wlib.makeWrapper` to help with this.

--- a/lib/makeWrapper/makeWrapper.nix
+++ b/lib/makeWrapper/makeWrapper.nix
@@ -19,13 +19,8 @@ let
     else
       [ "--inherit-argv0" ];
   baseArgs = map lib.escapeShellArg [
-    (
-      if !builtins.isString (config.exePath or null) || config.exePath == "" then
-        "${config.package}"
-      else
-        "${config.package}/${config.exePath}"
-    )
-    "${placeholder "out"}/${config.binDir or "bin"}/${config.binName}"
+    config.wrapperPaths.input
+    config.wrapperPaths.placeholder
   ];
   split = wlib.makeWrapper.splitDal (wlib.makeWrapper.aggregateSingleOptionSet { inherit config; });
   cliArgs = lib.pipe split.args [
@@ -104,21 +99,14 @@ let
 
   srcsetup = p: "source ${lib.escapeShellArg "${p}/nix-support/setup-hook"}";
 in
-if
-  !builtins.isString (config.binName or null)
-  || config.binName == ""
-  || !(lib.isStringLike (config.package or null))
-then
-  ""
-else
-  ''
-    (
-      OLD_OPTS="$(set +o)"
-      ${srcsetup dieHook}
-      ${srcsetup (
-        if config.wrapperImplementation or null != "binary" then makeWrapper else makeBinaryWrapper
-      )}
-      eval "$OLD_OPTS"
-      makeWrapper ${makeWrapperArgs}
-    )
-  ''
+''
+  (
+    OLD_OPTS="$(set +o)"
+    ${srcsetup dieHook}
+    ${srcsetup (
+      if config.wrapperImplementation or null != "binary" then makeWrapper else makeBinaryWrapper
+    )}
+    eval "$OLD_OPTS"
+    makeWrapper ${makeWrapperArgs}
+  )
+''

--- a/lib/makeWrapper/makeWrapperNix.nix
+++ b/lib/makeWrapper/makeWrapperNix.nix
@@ -20,8 +20,7 @@ let
       config.suffixVar or [ ] != [ ] || config.suffixContent or [ ] != [ ]
     ) suffixvarfunc;
 
-  outdir = "${placeholder "out"}/${config.binDir or "bin"}";
-  outpath = lib.escapeShellArg "${outdir}/${config.binName}";
+  outpath = lib.escapeShellArg config.wrapperPaths.placeholder;
   wrapcmd = partial: "echo ${lib.escapeShellArg partial} >> ${outpath}";
 
   arg0 = if builtins.isString (config.argv0 or null) then config.argv0 else "\"$0\"";
@@ -58,12 +57,7 @@ let
     )
   ];
 
-  finalcmd = "${
-    if !builtins.isString (config.exePath or null) || config.exePath == "" then
-      "${config.package}"
-    else
-      "${config.package}/${config.exePath}"
-  } ${args}";
+  finalcmd = "${config.wrapperPaths.input} ${args}";
 
   buildCommands = lib.pipe split.other [
     (
@@ -117,20 +111,13 @@ let
     (builtins.concatStringsSep "\n")
   ];
 in
-if
-  !builtins.isString (config.binName or null)
-  || config.binName == ""
-  || !(lib.isStringLike (config.package or null))
-then
-  ""
-else
-  ''
-    mkdir -p ${lib.escapeShellArg outdir}
-    echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > ${outpath}
-    ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
-    ${buildCommands}
-    ${lib.optionalString (!lib.isFunction (config.argv0type or null)) (
-      wrapcmd "exec -a ${arg0} ${finalcmd}"
-    )}
-    chmod +x ${outpath}
-  ''
+''
+  mkdir -p ${lib.escapeShellArg "${placeholder config.outputName}${config.wrapperPaths.relDir}"}
+  echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > ${outpath}
+  ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
+  ${buildCommands}
+  ${lib.optionalString (!lib.isFunction (config.argv0type or null)) (
+    wrapcmd "exec -a ${arg0} ${finalcmd}"
+  )}
+  chmod +x ${outpath}
+''

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -65,7 +65,7 @@
       options.myopts.xplr = lib.mkOption {
         type = wlib.types.subWrapperModule wlib.wrapperModules.xplr;
       };
-      # and access config.myopts.xplr.wrapped and set settings and options within it.
+      # and access config.myopts.xplr.wrapper and set settings and options within it.
     ```
   */
   subWrapperModule = module: wlib.types.subWrapperModuleWith { modules = lib.toList module; };

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -9,7 +9,7 @@ let
       mainConfig ? null,
       mainOpts ? null,
       ...
-    }:
+    }@top:
     {
       inherit _file;
       options.${if !(excluded.argv0type or false) then "argv0type" else null} = lib.mkOption {
@@ -65,13 +65,6 @@ let
           If unset or null, defaults to EXECUTABLE.
 
           overrides the setting from `argv0type` if set.
-        '';
-      };
-      options.${if !(excluded.binDir or false) then "binDir" else null} = lib.mkOption {
-        type = wlib.types.nonEmptyLine;
-        default = if mainConfig != null then mainConfig.binDir else "bin";
-        description = ''
-          Wrapped binary will be output to `"''${placeholder "out"}/<THIS_VALUE>/''${binName}"`
         '';
       };
       options.${if !(excluded.unsetVar or false) then "unsetVar" else null} = lib.mkOption {
@@ -540,7 +533,7 @@ let
                 modules = [
                   (options_module _file excluded false)
                   (
-                    { name, ... }:
+                    { name, config, ... }:
                     {
                       inherit _file;
                       options.enable = lib.mkOption {
@@ -559,7 +552,7 @@ let
                       };
                       options.exePath = lib.mkOption {
                         type = lib.types.nullOr wlib.types.nonEmptyLine;
-                        default = "bin/${name}";
+                        default = "${top.config.binDir}/${name}";
                         description = ''
                           The location within the package of the thing to wrap.
                         '';
@@ -568,12 +561,63 @@ let
                         type = wlib.types.nonEmptyLine;
                         default = name;
                         description = ''
-                          The name of the file to output to `$out/bin/`
+                          The name of the file to output to `''${placeholder config.outputName}''${config.wrapperPaths.relDir}`
                         '';
+                      };
+                      options.binDir = lib.mkOption {
+                        type = lib.types.nullOr wlib.types.nonEmptyLine;
+                        default = top.config.binDir or "bin";
+                        description = ''
+                          the directory the wrapped result will be placed into, with the name indicated by the `binName` option
+
+                          i.e. `"''${placeholder outputName}/<THIS_VALUE>/''${binName}"`
+                        '';
+                      };
+                      options.outputName = lib.mkOption {
+                        type = wlib.types.nonEmptyLine;
+                        default = top.config.outputName or "out";
+                        description = ''
+                          The derivation output the wrapped binary will be placed into.
+                        '';
+                      };
+                      options.wrapperPaths = {
+                        input = lib.mkOption {
+                          type = lib.types.str;
+                          readOnly = true;
+                          default = "${config.package}" + lib.optionalString (config.exePath != null) "/${config.exePath}";
+                          description = "
+                            The path which is to be wrapped by the wrapperFunction implementation
+                          ";
+                        };
+                        placeholder = lib.mkOption {
+                          type = lib.types.str;
+                          readOnly = true;
+                          default = "${placeholder config.outputName or "out"}${config.wrapperPaths.relPath}";
+                          description = "
+                            The path which the wrapperFunction implementation is to output its result to.
+                          ";
+                        };
+                        relPath = lib.mkOption {
+                          type = lib.types.str;
+                          readOnly = true;
+                          default =
+                            config.wrapperPaths.relDir + lib.optionalString (config.binName != "") "/${config.binName}";
+                          description = ''
+                            The binary will be output to `''${placeholder config.outputName}''${config.wrapperPaths.relPath}`
+                          '';
+                        };
+                        relDir = lib.mkOption {
+                          type = lib.types.str;
+                          readOnly = true;
+                          default = lib.optionalString (config.binDir != null) "/${config.binDir}";
+                          description = ''
+                            The binary will be output to `''${placeholder config.outputName}''${config.wrapperPaths.relDir}/''${config.binName}`
+                          '';
+                        };
                       };
                       options.package = lib.mkOption {
                         type = wlib.types.stringable;
-                        default = config.package;
+                        default = top.config.package;
                         description = ''
                           The package to wrap with these options
                         '';

--- a/modules/symlinkScript/module.nix
+++ b/modules/symlinkScript/module.nix
@@ -47,6 +47,8 @@
       inherit (config)
         package
         aliases
+        outputName
+        wrapperPaths
         filesToPatch
         filesToExclude
         binName
@@ -54,80 +56,82 @@
         ;
       originalOutputs = wlib.getPackageOutputsSet package;
     in
-    "mkdir -p $out \n"
+    "mkdir -p ${placeholder outputName} \n"
     + (
       if builtins.isString wrapper then
         wrapper
+      else if wrapper != null then
+        "${lndir}/bin/lndir -silent \"${toString wrapper}\" ${placeholder outputName}"
       else
-        "${lndir}/bin/lndir -silent \"${toString wrapper}\" $out"
+        ""
     )
     + ''
-
-      ${lndir}/bin/lndir -silent "${toString package}" $out
-
-      # Exclude specified files
-      ${lib.optionalString (filesToExclude != [ ]) ''
-        echo "Excluding specified files..."
-        ${lib.concatMapStringsSep "\n" (pattern: ''
-          for file in $out/${pattern}; do
-            if [[ -e "$file" ]]; then
-              echo "Removing $file"
-              rm -f "$file"
-            fi
-          done
-        '') filesToExclude}
-      ''}
-
-      # Patch specified files to replace references to the original package with the wrapped one
-      ${lib.optionalString (filesToPatch != [ ]) ''
-        echo "Patching self-references in specified files..."
-        oldPath="${package}"
-        newPath="$out"
-
-        # Process each file pattern
-        ${lib.concatMapStringsSep "\n" (pattern: ''
-          for file in $out/${pattern}; do
-            if [[ -L "$file" ]]; then
-              # It's a symlink, we need to resolve it
-              target=$(readlink -f "$file")
-
-              # Check if the file contains the old path
-              if grep -qF "$oldPath" "$target" 2>/dev/null; then
-                echo "Patching $file"
-                # Remove symlink and create a real file with patched content
-                rm "$file"
-                # Use replace-literal which works for both text and binary files
-                replace-literal "$oldPath" "$newPath" < "$target" > "$file"
-                # Preserve permissions
-                chmod --reference="$target" "$file"
-              fi
-            fi
-          done
-        '') filesToPatch}
-      ''}
-
-      # Create symlinks for aliases
-      ${lib.optionalString (aliases != [ ] && binName != "") ''
-        mkdir -p $out/bin
-        for alias in ${lib.concatStringsSep " " (map lib.escapeShellArg aliases)}; do
-          ln -sf ${lib.escapeShellArg binName} $out/bin/$alias
-        done
-      ''}
 
       # Handle additional outputs by symlinking from the original package's outputs
       ${lib.concatMapStringsSep "\n" (
         output:
-        if output != "out" && originalOutputs ? ${output} && originalOutputs.${output} != null then
+        if originalOutputs ? ${output} && originalOutputs.${output} != null then
           ''
+
             if [[ -n "''${${output}:-}" ]]; then
-              mkdir -p ${"$" + output}
+              mkdir -p ${placeholder output}
               # Only symlink from the original package's corresponding output
-              ${lndir}/bin/lndir -silent "${originalOutputs.${output}}" ${"$" + output}
+              ${lndir}/bin/lndir -silent "${originalOutputs.${output}}" ${placeholder output}
             fi
+
+            # Exclude specified files for ${output}
+            ${lib.optionalString (filesToExclude != [ ]) ''
+              echo "Excluding specified files..."
+              ${lib.concatMapStringsSep "\n" (pattern: ''
+                for file in ${placeholder output}/${pattern}; do
+                  if [[ -e "$file" ]]; then
+                    echo "Removing $file"
+                    rm -f "$file"
+                  fi
+                done
+              '') filesToExclude}
+            ''}
+
+            # Patch specified files to replace references to the original package with the wrapped one
+            ${lib.optionalString (filesToPatch != [ ]) ''
+              echo "Patching self-references in specified files..."
+              oldPath="${originalOutputs.${output}}"
+              newPath="${placeholder output}"
+
+              # Process each file pattern
+              ${lib.concatMapStringsSep "\n" (pattern: ''
+                for file in ${placeholder output}/${pattern}; do
+                  if [[ -L "$file" ]]; then
+                    # It's a symlink, we need to resolve it
+                    target=$(readlink -f "$file")
+
+                    # Check if the file contains the old path
+                    if grep -qF "$oldPath" "$target" 2>/dev/null; then
+                      echo "Patching $file"
+                      # Remove symlink and create a real file with patched content
+                      rm "$file"
+                      # Use replace-literal which works for both text and binary files
+                      replace-literal "$oldPath" "$newPath" < "$target" > "$file"
+                      # Preserve permissions
+                      chmod --reference="$target" "$file"
+                    fi
+                  fi
+                done
+              '') filesToPatch}
+            ''}
+
           ''
         else
           ""
       ) outputs}
+
+      # Create symlinks for aliases
+      ${lib.optionalString (aliases != [ ] && binName != "") ''
+        mkdir -p ${placeholder outputName}/bin
+        for alias in ${lib.concatStringsSep " " (map lib.escapeShellArg aliases)}; do
+          ln -sf ${wrapperPaths.placeholder} ${placeholder config.outputName}/bin/$alias
+        done
+      ''}
 
     ''
   );

--- a/wrapperModules/a/aria2/module.nix
+++ b/wrapperModules/a/aria2/module.nix
@@ -46,11 +46,10 @@ in
         runHook preBuild
         mkdir -p $conf
         cp $renderedSettingsPath "$conf/${config.binName}-settings.conf"
-        rm $bin/bin/aria2c
-        cp $out/bin/aria2c $bin/bin
         runHook postBuild
       '';
     };
+    wrapperVariants.aria2c.outputName = "out";
     meta.maintainers = [ wlib.maintainers.rachitvrma ];
   };
 }

--- a/wrapperModules/b/btop/module.nix
+++ b/wrapperModules/b/btop/module.nix
@@ -17,7 +17,7 @@ let
         else if builtins.isString v then
           ''"${v}"''
         else
-          builtins.toString v;
+          toString v;
     } " = ";
   };
 
@@ -25,7 +25,7 @@ let
     name: theme:
     if builtins.isPath theme || lib.isStorePath theme then theme else pkgs.writeText "btop.theme" theme;
 
-  themesDir = "${builtins.placeholder "out"}/themes";
+  themesDir = "${placeholder config.outputName}/themes";
 in
 {
   imports = [ wlib.modules.default ];

--- a/wrapperModules/m/mdbook/module.nix
+++ b/wrapperModules/m/mdbook/module.nix
@@ -205,7 +205,7 @@ in
       description = ''
         The books are generated to:
 
-        `''${placeholder "out"}/''${config.book-out-dir}/''${name}`
+        `''${placeholder config.outputName}/''${config.book-out-dir}/''${name}`
       '';
     };
     books = lib.mkOption {
@@ -353,7 +353,7 @@ in
                 description = ''
                   The directory within the wrapped derivation that contains the generated markdown for the book.
 
-                  `''${placeholder "out"}/''${config.books.<name>.generated-book-subdir}` is the root of this book.
+                  `''${placeholder config.outputName}/''${config.books.<name>.generated-book-subdir}` is the root of this book.
                 '';
               };
             };
@@ -374,7 +374,7 @@ in
     wrapperVariants = builtins.mapAttrs (_: v: {
       config.appendFlag = [
         {
-          data = "${placeholder "out"}/${v.generated-book-subdir}";
+          data = "${placeholder config.outputName}/${v.generated-book-subdir}";
           name = "GENERATED_MD_BOOK";
         }
       ];
@@ -431,7 +431,7 @@ in
         (builtins.mapAttrs (
           n: v:
           let
-            src = "${placeholder "out"}/${v.generated-book-subdir}/${
+            src = "${placeholder config.outputName}/${v.generated-book-subdir}/${
               lib.removePrefix "/" (lib.removeSuffix "/" (v.book.book.src or "src"))
             }";
             pages = renderBook src v.summary n;
@@ -441,7 +441,7 @@ in
             book = builtins.toJSON (
               lib.filterAttrsRecursive (_: v: !builtins.isFunction v && v != null) v.book
             );
-            root = "${placeholder "out"}/${v.generated-book-subdir}";
+            root = "${placeholder config.outputName}/${v.generated-book-subdir}";
             inherit src;
             build = pages.linkCmds;
           }
@@ -477,8 +477,7 @@ in
             && config.books."${config.mainBook}".enable or false == true
           )
           ''
-            rm -f $out/bin/${config.binName}
-            ln -s ${config.mainBook} $out/bin/${config.binName}
+            ln -sf ${config.mainBook} ${config.wrapperPaths.placeholder}
           ''
       + "\nrunHook postBuild";
     };
@@ -495,7 +494,7 @@ in
       you only have access to the other flags on these items at runtime.
 
       To achieve greater runtime control, run the main executable with one of the generated books within the derivation
-      as input yourself, either at runtime, or within the module via `''${placeholder "out"}/''${config.book-out-dir}/''${name}`
+      as input yourself, either at runtime, or within the module via `''${placeholder config.outputName}/''${config.book-out-dir}/''${name}`
 
       Within the module, there is an option called `mainBook` to REPLACE the main executable with a symlink to the desired book generation script.
 

--- a/wrapperModules/n/neovim/default-config.nix
+++ b/wrapperModules/n/neovim/default-config.nix
@@ -361,7 +361,7 @@
       # NOTE: nvim runs the thing with `node vim.g.node_host_prog`, we can't wrap it
       # maybe we could replace the shebang with a wrapped node at some point?
       # You can wrap it for when it gets linked into ${placeholder "out"}/bin though
-      config.nvim-host.var_path = "${config.package}/${config.exePath}";
+      config.nvim-host.var_path = config.wrapperPaths.input;
     };
   config.hosts.ruby =
     {
@@ -375,7 +375,7 @@
       imports = [ wlib.modules.default ];
       config.package = lib.makeOverridable pkgs.bundlerEnv {
         name = "neovim-ruby-host";
-        postBuild = "ln -sf ${pkgs.ruby}/bin/* $out/bin";
+        postBuild = "ln -sf ${pkgs.ruby}/bin/* ${placeholder config.outputName}/bin";
         gemdir = config.gemdir;
       };
       options.gemdir = lib.mkOption {
@@ -399,6 +399,6 @@
       imports = [ wlib.modules.default ];
       config.nvim-host.enable = lib.mkDefault false;
       config.package = pkgs.neovide;
-      config.nvim-host.flags."--neovim-bin" = "${placeholder "out"}/bin/${config.binName}";
+      config.nvim-host.flags."--neovim-bin" = config.wrapperPaths.placeholder;
     };
 }

--- a/wrapperModules/n/neovim/makeWrapper/makeWrapper.nix
+++ b/wrapperModules/n/neovim/makeWrapper/makeWrapper.nix
@@ -57,10 +57,10 @@ let
     )
   ];
 
-  luarc-path = "${placeholder "out"}/${config.binName}-rc.lua";
+  luarc-path = "${placeholder config.outputName}/${config.binName or ""}-rc.lua";
   baseArgs = map lib.escapeShellArg [
-    (if config.exePath == "" then "${config.package}" else "${config.package}/${config.exePath}")
-    "${placeholder "out"}/${config.binDir or "bin"}/${config.binName}"
+    config.wrapperPaths.input
+    config.wrapperPaths.placeholder
     "--add-flag"
     "--cmd"
     "--add-flag"
@@ -69,7 +69,7 @@ let
   luaEnv = (config.package.lua.withPackages or luajit.withPackages) config.settings.nvim_lua_env;
   NVIM_LUA_PATH = ((config.package.lua or luajit).pkgs.luaLib.genLuaPathAbsStr luaEnv);
   NVIM_LUA_CPATH = ((config.package.lua or luajit).pkgs.luaLib.genLuaCPathAbsStr luaEnv);
-  manifest-path = lib.escapeShellArg "${placeholder "out"}/${config.binName}-rplugin.vim";
+  manifest-path = lib.escapeShellArg "${placeholder config.outputName}/${config.binName or ""}-rplugin.vim";
   makeWrapperCmd =
     isFinal:
     lib.pipe split.other [
@@ -170,33 +170,26 @@ let
 
   srcsetup = p: "source ${lib.escapeShellArg "${p}/nix-support/setup-hook"}";
 in
-if
-  !builtins.isString (config.binName or null)
-  || config.binName == ""
-  || !(lib.isStringLike (config.package or null))
-then
-  ""
-else
-  /* bash */ ''
-    (
-      OLD_OPTS="$(set +o)"
-      ${srcsetup dieHook}
-      ${srcsetup (if config.wrapperImplementation == "binary" then makeBinaryWrapper else makeWrapper)}
-      eval "$OLD_OPTS"
-      mkdir -p $out/bin
-      { [ -e "$manifestLuaPath" ] && cat "$manifestLuaPath" || echo "$manifestLua"; } > ${lib.escapeShellArg luarc-path}
-      export NVIM_RPLUGIN_MANIFEST=${manifest-path}
-      export HOME="$(mktemp -d)"
-      ${makeWrapperCmd false}
+/* bash */ ''
+  (
+    OLD_OPTS="$(set +o)"
+    ${srcsetup dieHook}
+    ${srcsetup (if config.wrapperImplementation == "binary" then makeBinaryWrapper else makeWrapper)}
+    eval "$OLD_OPTS"
+    mkdir -p ${lib.escapeShellArg "${placeholder config.outputName}${config.wrapperPaths.relDir}"}
+    { [ -e "$manifestLuaPath" ] && cat "$manifestLuaPath" || echo "$manifestLua"; } > ${lib.escapeShellArg luarc-path}
+    export NVIM_RPLUGIN_MANIFEST=${manifest-path}
+    export HOME="$(mktemp -d)"
+    ${makeWrapperCmd false}
 
-      if ! $out/bin/${config.binName} -i NONE -n -V1rplugins.log \
-        +UpdateRemotePlugins +quit! > outfile 2>&1; then
-        cat outfile
-        echo -e "\nGenerating rplugin.vim failed!"
-        exit 1
-      fi
-      rm -f "$out/bin/${config.binName}"
-      { [ -e "$setupLuaPath" ] && cat "$setupLuaPath" || echo "$setupLua"; } ${maybe_compile}> ${lib.escapeShellArg luarc-path}
-      ${makeWrapperCmd true}
-    )
-  ''
+    if ! ${config.wrapperPaths.placeholder} -i NONE -n -V1rplugins.log \
+      +UpdateRemotePlugins +quit! > outfile 2>&1; then
+      cat outfile
+      echo -e "\nGenerating rplugin.vim failed!"
+      exit 1
+    fi
+    rm -f "${config.wrapperPaths.placeholder}"
+    { [ -e "$setupLuaPath" ] && cat "$setupLuaPath" || echo "$setupLua"; } ${maybe_compile}> ${lib.escapeShellArg luarc-path}
+    ${makeWrapperCmd true}
+  )
+''

--- a/wrapperModules/n/neovim/makeWrapper/makeWrapperNix.nix
+++ b/wrapperModules/n/neovim/makeWrapper/makeWrapperNix.nix
@@ -22,8 +22,7 @@ let
     ++ lib.optional (config.prefixVar or [ ] != [ ] || config.prefixContent or [ ] != [ ]) prefixvarfunc
     ++ lib.optional (config.env or { } != { }) setvarfunc;
 
-  outdir = "${placeholder "out"}/${config.binDir or "bin"}";
-  outpath = lib.escapeShellArg "${outdir}/${config.binName}";
+  outpath = lib.escapeShellArg config.wrapperPaths.placeholder;
   wrapcmd = partial: "echo ${lib.escapeShellArg partial} >> ${outpath}";
 
   arg0 = if builtins.isString (config.argv0 or null) then config.argv0 else "\"$0\"";
@@ -60,7 +59,7 @@ let
     )
   ];
 
-  luarc-path = "${placeholder "out"}/${config.binName}-rc.lua";
+  luarc-path = "${placeholder config.outputName}/${config.binName or ""}-rc.lua";
   finalcmd = "${
     if config.exePath == "" then "${config.package}" else "${config.package}/${config.exePath}"
   } --cmd ${lib.escapeShellArg "source${luarc-path}"} ${args}";
@@ -69,7 +68,7 @@ let
   NVIM_LUA_PATH = ((config.package.lua or luajit).pkgs.luaLib.genLuaPathAbsStr luaEnv);
   NVIM_LUA_CPATH = ((config.package.lua or luajit).pkgs.luaLib.genLuaCPathAbsStr luaEnv);
 
-  manifest-path = lib.escapeShellArg "${placeholder "out"}/${config.binName}-rplugin.vim";
+  manifest-path = lib.escapeShellArg "${placeholder config.outputName}/${config.binName or ""}-rplugin.vim";
 
   buildCommands =
     isFinal:
@@ -157,34 +156,27 @@ let
       (builtins.concatStringsSep "\n")
     ];
 in
-if
-  !builtins.isString (config.binName or null)
-  || config.binName == ""
-  || !(lib.isStringLike (config.package or null))
-then
-  ""
-else
-  /* bash */ ''
-    mkdir -p ${lib.escapeShellArg outdir}
-    { [ -e "$manifestLuaPath" ] && cat "$manifestLuaPath" || echo "$manifestLua"; } > ${lib.escapeShellArg luarc-path}
-    echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > ${outpath}
-    ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
-    ${buildCommands false}
-    ${wrapcmd "exec -a ${arg0} ${finalcmd}"}
-    chmod +x ${outpath}
+/* bash */ ''
+  mkdir -p ${lib.escapeShellArg "${placeholder config.outputName}${config.wrapperPaths.relDir}"}
+  { [ -e "$manifestLuaPath" ] && cat "$manifestLuaPath" || echo "$manifestLua"; } > ${lib.escapeShellArg luarc-path}
+  echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > ${outpath}
+  ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
+  ${buildCommands false}
+  ${wrapcmd "exec -a ${arg0} ${finalcmd}"}
+  chmod +x ${outpath}
 
-    export NVIM_RPLUGIN_MANIFEST=${manifest-path}
-    export HOME="$(mktemp -d)"
-    if ! $out/bin/${config.binName} -i NONE -n -V1rplugins.log \
-      +UpdateRemotePlugins +quit! > outfile 2>&1; then
-      cat outfile
-      echo -e "\nGenerating rplugin.vim failed!"
-      exit 1
-    fi
-    { [ -e "$setupLuaPath" ] && cat "$setupLuaPath" || echo "$setupLua"; } ${maybe_compile}> ${lib.escapeShellArg luarc-path}
-    echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > ${outpath}
-    ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
-    ${buildCommands true}
-    ${lib.optionalString (!lib.isFunction config.argv0type) (wrapcmd "exec -a ${arg0} ${finalcmd}")}
-    chmod +x ${outpath}
-  ''
+  export NVIM_RPLUGIN_MANIFEST=${manifest-path}
+  export HOME="$(mktemp -d)"
+  if ! ${config.wrapperPaths.placeholder} -i NONE -n -V1rplugins.log \
+    +UpdateRemotePlugins +quit! > outfile 2>&1; then
+    cat outfile
+    echo -e "\nGenerating rplugin.vim failed!"
+    exit 1
+  fi
+  { [ -e "$setupLuaPath" ] && cat "$setupLuaPath" || echo "$setupLua"; } ${maybe_compile}> ${lib.escapeShellArg luarc-path}
+  echo ${lib.escapeShellArg "#!${bash}/bin/bash"} > ${outpath}
+  ${wrapcmd (builtins.concatStringsSep "\n" prefuncs)}
+  ${buildCommands true}
+  ${lib.optionalString (!lib.isFunction config.argv0type) (wrapcmd "exec -a ${arg0} ${finalcmd}")}
+  chmod +x ${outpath}
+''

--- a/wrapperModules/n/neovim/module.nix
+++ b/wrapperModules/n/neovim/module.nix
@@ -4,7 +4,7 @@
   wlib,
   lib,
   ...
-}:
+}@top:
 let
   makeWrapper = import wlib.modules.makeWrapper;
   inherit (lib) types;
@@ -30,99 +30,145 @@ let
     lib.types.submoduleWith {
       specialArgs = { inherit wlib; };
       modules = [
-        {
-          imports = [
-            (
-              makeWrapper
-              // {
-                excluded_options.wrapperVariants = true;
-                exclude_wrapper = true;
-                exclude_meta = true;
-              }
-            )
-          ];
-          options = {
-            # These internal options will allow us to call
-            # the regular function from the makeWrapper module for each host,
-            # but in the context of the outer wrapped nvim derivation.
-            binName = lib.mkOption {
-              type = lib.types.str;
-              default = "${config.binName}-${name}";
-              readOnly = true;
-              internal = true;
-              description = "placeholder option";
-            };
-            exePath = lib.mkOption {
-              type = lib.types.raw;
-              default = null;
-              readOnly = true;
-              internal = true;
-              description = "placeholder option";
-            };
-            enabled_variable = lib.mkOption {
-              type = wlib.types.nonEmptyLine;
-              default = "${name}_host_prog";
-              description = ''
-                `vim.g.<value>` will be set to the path to this wrapped host when the nvim host is enabled
-              '';
-            };
-            disabled_variable = lib.mkOption {
-              type = wlib.types.nonEmptyLine;
-              default = "loaded_${name}_provider";
-              description = ''
-                `vim.g.<value>` will be set to 0 when the nvim host is disabled
-              '';
-            };
-            var_path = lib.mkOption {
-              type = wlib.types.nonEmptyLine;
-              default = "${placeholder "out"}/bin/${config.binName}-${name}";
-              description = ''
-                The path to be added to `vim.g.<enabled_variable>`
+        (
+          { config, ... }:
+          {
+            imports = [
+              (
+                makeWrapper
+                // {
+                  excluded_options.wrapperVariants = true;
+                  exclude_wrapper = true;
+                  exclude_meta = true;
+                }
+              )
+            ];
+            options = {
+              # These internal options will allow us to call
+              # the regular function from the makeWrapper module for each host,
+              # but in the context of the outer wrapped nvim derivation.
+              binName = lib.mkOption {
+                type = lib.types.str;
+                default = "${top.config.binName}-${name}";
+                readOnly = true;
+                internal = true;
+                description = "placeholder option";
+              };
+              outputName = lib.mkOption {
+                type = wlib.types.nonEmptyLine;
+                default = top.config.outputName or "out";
+                description = ''
+                  The derivation output to place the wrapped result into in the final neovim derivation.
+                '';
+              };
+              binDir = lib.mkOption {
+                type = wlib.types.nonEmptyLine;
+                default = "bin";
+                description = ''
+                  The directory within the derivation output to place the wrapped result into in the final neovim derivation.
+                '';
+              };
+              wrapperPaths = {
+                input = lib.mkOption {
+                  default = config.package;
+                  type = lib.types.str;
+                  readOnly = true;
+                  description = ''
+                    The path which is to be wrapped by the wrapperFunction implementation
+                  '';
+                };
+                relPath = lib.mkOption {
+                  default = "/${config.binDir}/${config.binName}";
+                  type = lib.types.str;
+                  readOnly = true;
+                  description = ''
+                    The binary will be output to `$''${placeholder config.outputName}''${config.wrapperPaths.relPath}`
+                  '';
+                };
+                relDir = lib.mkOption {
+                  default = "/${config.binDir}";
+                  type = lib.types.str;
+                  readOnly = true;
+                  description = ''
+                    The binary will be output to `$''${placeholder config.outputName}''${config.wrapperPaths.relDir}/''${config.binName}`
+                  '';
+                };
+                placeholder = lib.mkOption {
+                  default = "${placeholder config.outputName}${config.wrapperPaths.relPath}";
+                  type = lib.types.str;
+                  readOnly = true;
+                  description = ''
+                    The path which the wrapperFunction implementation is to output its result to.
+                  '';
+                };
+              };
+              enabled_variable = lib.mkOption {
+                type = wlib.types.nonEmptyLine;
+                default = "${name}_host_prog";
+                description = ''
+                  `vim.g.<value>` will be set to the path to this wrapped host when the nvim host is enabled
+                '';
+              };
+              disabled_variable = lib.mkOption {
+                type = wlib.types.nonEmptyLine;
+                default = "loaded_${name}_provider";
+                description = ''
+                  `vim.g.<value>` will be set to 0 when the nvim host is disabled
+                '';
+              };
+              var_path = lib.mkOption {
+                type = wlib.types.nonEmptyLine;
+                default = config.wrapperPaths.placeholder;
+                description = ''
+                  The path to be added to `vim.g.<enabled_variable>`
 
-                By default, the result of wrapping `nvim-host.package` with the
-                other `nvim-host.*` options in the context of the outer neovim wrapper will be used.
-              '';
+                  By default, the result of wrapping `nvim-host.package` with the
+                  other `nvim-host.*` options in the context of the outer neovim wrapper will be used.
+                '';
+              };
+              dontWrap = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = ''
+                  If true, do not process any `hosts.*.nvim-host` options for this host other than:
+
+                  `nvim-host.enable`,
+                  `nvim-host.package`,
+                  `nvim-host.var_path`,
+                  `nvim-host.outputName`,
+                  `nvim-host.binDir`,
+                  `nvim-host.enabled_variable`,
+                  `nvim-host.disabled_variable`
+                '';
+              };
+              package = lib.mkOption {
+                type = wlib.types.nonEmptyLine;
+                default = "${hostConfig.wrapper}${hostConfig.wrapperPaths.relPath}";
+                description = ''
+                  The full path to be added to the `PATH` alongside the main nvim wrapper.
+
+                  By default, the binary from this host wrapper module will be used.
+
+                  This is the path which gets wrapped in the context of the nvim wrapper by the nvim-host options
+
+                  This allows you to wrap this path in the context of the overall nvim derivation,
+                  and thus have access to that path via `placeholder "out"`
+                '';
+              };
+              enable = lib.mkOption {
+                type = lib.types.bool;
+                default = true;
+                description = ''
+                  Enable this nvim host program.
+
+                  If enabled it will be added to the path alongside the nvim wrapper.
+
+                  It will also propagate options provided in this set to the nvim wrapper.
+                '';
+              };
             };
-            dontWrap = lib.mkOption {
-              type = lib.types.bool;
-              default = false;
-              description = ''
-                If true, do not process any `hosts.*.nvim-host` options for this host other than:
-
-                `nvim-host.enable`,
-                `nvim-host.package`,
-                `nvim-host.var_path`,
-                `nvim-host.enabled_variable`,
-                `nvim-host.disabled_variable`
-              '';
-            };
-            package = lib.mkOption {
-              type = wlib.types.nonEmptyLine;
-              default = "${hostConfig.wrapper}/bin/${hostConfig.binName}";
-              description = ''
-                The full path to be added to the `PATH` alongside the main nvim wrapper.
-
-                By default, the binary from this host wrapper module will be used.
-
-                This is the path which gets wrapped in the context of the nvim wrapper by the nvim-host options
-
-                This allows you to wrap this path in the context of the overall nvim derivation,
-                and thus have access to that path via `placeholder "out"`
-              '';
-            };
-            enable = lib.mkOption {
-              type = lib.types.bool;
-              default = true;
-              description = ''
-                Enable this nvim host program.
-
-                If enabled it will be added to the path alongside the nvim wrapper.
-
-                It will also propagate options provided in this set to the nvim wrapper.
-              '';
-            };
-          };
-        }
+          }
+        )
       ];
     };
 in
@@ -200,7 +246,7 @@ in
         This allows you to do things like
 
         ```nix
-        hosts.neovide.nvim-host.flags."--neovim-bin" = "''${placeholder "out"}/bin/''${config.binName}";
+        hosts.neovide.nvim-host.flags."--neovim-bin" = "''${config.wrapperPaths.placeholder}";
         ```
 
         If you do `hosts.neovide.nvim-host.enable = true;` it will do that for you.
@@ -442,7 +488,7 @@ in
       description = ''
         extra module for the plugin spec submodules (provided to `wlib.types.specWith`)
 
-        These modules recieve some `specialArgs`!
+        These modules receive some `specialArgs`!
 
         `parentSpec`, `parentOpts`, and `parentName`
 
@@ -586,9 +632,9 @@ in
       description = ''
         supply a DAL list of functions
 
-        Each function recieves the WHOLE final list of specs, in a particular format.
+        Each function receives the WHOLE final list of specs, in a particular format.
 
-        Each one recieves `[ { name = "attrName"; type = "spec" | "parent"; value = spec; } /* ... */ ]`
+        Each one receives `[ { name = "attrName"; type = "spec" | "parent"; value = spec; } /* ... */ ]`
 
         Each one returns the same structure, but with your alterations.
 
@@ -619,7 +665,7 @@ in
 
         `mappedSpecs` in the above snippet is the result after all `config.specMaps` have been applied.
 
-        You will recieve JUST the specs, unlike `config.specMaps`, which recieves specs wrapped in an outer set with more info
+        You will receive JUST the specs, unlike `config.specMaps`, which receives specs wrapped in an outer set with more info
 
         This function offered by this option allows you to use items collected from the final specs, to provide them to other options.
       '';

--- a/wrapperModules/n/neovim/packDir.nix
+++ b/wrapperModules/n/neovim/packDir.nix
@@ -16,7 +16,8 @@ let
               attrname = n;
               inherit (v.nvim-host) disabled_variable enabled_variable;
               setvarcmd = "vim.g[ ${builtins.toJSON v.nvim-host.enabled_variable} ] = ${builtins.toJSON v.nvim-host.var_path}";
-              bin_path = config.nvim-host.package;
+              bin_path = v.nvim-host.package;
+              out_path = v.nvim-host.wrapperPaths.placeholder;
             }
             // lib.optionalAttrs (!v.nvim-host.dontWrap) {
               config = v.nvim-host;
@@ -34,8 +35,7 @@ let
           (map (v: {
             name = v.attrname;
             value = {
-              bin_path =
-                if v ? bin_path then "${placeholder "out"}/bin/${config.binName}-${v.attrname}" else null;
+              bin_path = if v ? out_path then "${v.out_path}" else null;
               var_path = lib.generators.mkLuaInline "vim.g[ ${builtins.toJSON v.enabled_variable} ]";
               inherit (v) disabled_variable enabled_variable;
             };
@@ -54,10 +54,10 @@ let
                   inherit (pkgs) callPackage;
                 })
               ]
-            else if v ? bin_path then
+            else if v ? bin_path && v ? out_path then
               acc
               ++ [
-                "ln -s ${lib.escapeShellArg v.bin_path} ${lib.escapeShellArg "${placeholder "out"}/bin/${config.binName}-${v.attrname}"}"
+                "ln -s ${lib.escapeShellArg v.bin_path} ${lib.escapeShellArg v.out_path}"
               ]
             else
               acc
@@ -82,7 +82,7 @@ let
     buildPackDir
     mappedSpecs
     ;
-  vim_pack_dir = "${placeholder "out"}/${config.binName}-packdir";
+  vim_pack_dir = "${placeholder config.outputName}/${config.binName}-packdir";
   start_dir = "${vim_pack_dir}/pack/myNeovimPackages/start";
   opt_dir = "${vim_pack_dir}/pack/myNeovimPackages/opt";
   info_plugin_path = "${start_dir}/${config.settings.info_plugin_name}";
@@ -102,8 +102,8 @@ in
             (config.package.lua.withPackages or pkgs.luajit.withPackages)
               config.settings.nvim_lua_env;
         };
-        wrapper_drv = placeholder "out";
-        progpath = "${placeholder "out"}/bin/${config.binName}";
+        wrapper_drv = placeholder config.outputName;
+        progpath = config.wrapperPaths.placeholder;
         inherit (config) info binName;
         inherit
           plugins

--- a/wrapperModules/n/neovim/post_desc.md
+++ b/wrapperModules/n/neovim/post_desc.md
@@ -242,11 +242,11 @@ config.hosts.neovide =
     config.nvim-host.enable = lib.mkDefault false;
     config.package = pkgs.neovide;
     # also offers nvim-host wrapper arguments which run in the context of the final nvim drv!
-    config.nvim-host.flags."--neovim-bin" = "${placeholder "out"}/bin/${config.binName}";
+    config.nvim-host.flags."--neovim-bin" = config.wrapperPaths.placeholder;
   };
 
   # This one is included!
-  # To add a wrapped $out/bin/${config.binName}-neovide to the resulting neovim derivation
+  # To add a wrapped ${placeholder config.outputName}/bin/${config.binName}-neovide to the resulting neovim derivation
   config.hosts.neovide.nvim-host.enable = true;
 ```
 

--- a/wrapperModules/n/neovim/symlinkScript.nix
+++ b/wrapperModules/n/neovim/symlinkScript.nix
@@ -12,7 +12,7 @@
 }:
 finalDrv:
 let
-  final-packdir = "${placeholder "out"}/${config.binName}-packdir";
+  final-packdir = "${placeholder outputName}/${binName}-packdir";
   start-dir = "${final-packdir}/pack/myNeovimPackages/start";
   opt-dir = "${final-packdir}/pack/myNeovimPackages/opt";
   info-plugin-path = "${start-dir}/${config.settings.info_plugin_name}";
@@ -21,6 +21,8 @@ let
     package
     binName
     outputs
+    outputName
+    wrapperPaths
     ;
   inherit (config.settings) info_plugin_name dont_link aliases;
   originalOutputs = wlib.getPackageOutputsSet package;
@@ -47,7 +49,7 @@ let
 in
 finalDrv
 // {
-  outputs = if dont_link then [ "out" ] else outputs;
+  outputs = if dont_link then [ outputName ] else outputs;
   passAsFile = [
     "manifestLua"
     "setupLua"
@@ -74,24 +76,24 @@ finalDrv
     vim.opt.runtimepath:append(configdir .. "/after")
   '';
   buildCommand = ''
-    mkdir -p $out/bin
+    mkdir -p ${placeholder outputName}/bin
     [ -d ${package}/nix-support ] && \
-    mkdir -p $out/nix-support && \
-    cp -r ${package}/nix-support/* $out/nix-support
+    mkdir -p ${placeholder outputName}/nix-support && \
+    cp -r ${package}/nix-support/* ${placeholder outputName}/nix-support
 
   ''
   + lib.optionalString stdenv.isLinux ''
-    mkdir -p $out/share/applications
+    mkdir -p '${placeholder outputName}/share/applications'
     substitute ${
       lib.escapeShellArgs [
         "${package}/share/applications/nvim.desktop"
-        "${placeholder "out"}/share/applications/${binName}.desktop"
+        "${placeholder outputName}/share/applications/${binName}.desktop"
         "--replace-fail"
         "Name=Neovim"
         "Name=${binName}"
         "--replace-fail"
         "TryExec=nvim"
-        "TryExec=${placeholder "out"}/bin/${binName}"
+        "TryExec=${wrapperPaths.placeholder}"
         "--replace-fail"
         "Icon=nvim"
         "Icon=${package}/share/icons/hicolor/128x128/apps/nvim.png"
@@ -101,18 +103,18 @@ finalDrv
       lib.escapeShellArgs [
         ''
           /^Exec=nvim/c\
-          Exec=${placeholder "out"}/bin/${binName} %F''
-        "${placeholder "out"}/share/applications/${binName}.desktop"
+          Exec=${wrapperPaths.placeholder} %F''
+        "${placeholder outputName}/share/applications/${binName}.desktop"
       ]
-    } > ./tmp_desk && mv -f ./tmp_desk "${placeholder "out"}/share/applications/${binName}.desktop"
+    } > ./tmp_desk && mv -f ./tmp_desk "${placeholder outputName}/share/applications/${binName}.desktop"
   ''
   + ''
 
     # Create symlinks for aliases
     ${lib.optionalString (aliases != [ ] && binName != "") ''
-      mkdir -p $out/bin
+      mkdir -p '${placeholder outputName}/bin'
       for alias in ${lib.concatStringsSep " " (map lib.escapeShellArg aliases)}; do
-        ln -sf ${lib.escapeShellArg binName} $out/bin/$alias
+        ln -sf ${wrapperPaths.placeholder} ${placeholder outputName}/bin/$alias
       done
     ''}
 
@@ -147,17 +149,15 @@ finalDrv
   + "\n"
   + lib.optionalString (!dont_link) ''
 
-    ${lndir}/bin/lndir -silent "${toString package}" $out
-
     # Handle additional outputs by symlinking from the original package's outputs
     ${lib.concatMapStringsSep "\n" (
       output:
-      if output != "out" && originalOutputs ? ${output} && originalOutputs.${output} != null then
+      if originalOutputs ? ${output} && originalOutputs.${output} != null then
         ''
           if [[ -n "''${${output}:-}" ]]; then
-            mkdir -p ${"$" + output}
+            mkdir -p ${placeholder output}
             # Only symlink from the original package's corresponding output
-            ${lndir}/bin/lndir -silent "${originalOutputs.${output}}" ${"$" + output}
+            ${lndir}/bin/lndir -silent "${originalOutputs.${output}}" ${placeholder output}
           fi
         ''
       else

--- a/wrapperModules/n/niri/module.nix
+++ b/wrapperModules/n/niri/module.nix
@@ -200,7 +200,7 @@ in
           workspaces = lib.mkOption {
             default = { };
             type = lib.types.attrsOf (lib.types.nullOr lib.types.anything);
-            description = "Named workspace definitons";
+            description = "Named workspace definitions";
             example = {
               "foo" = {
                 open-on-output = "DP-3";

--- a/wrapperModules/w/wezterm/module.nix
+++ b/wrapperModules/w/wezterm/module.nix
@@ -42,7 +42,7 @@
 
       This means, by default, this will act like your wezterm config file, unless you want to add some lua in between there.
 
-      `''${placeholder "out"}` is useable here and will point to the final wrapper derivation
+      `''${placeholder config.outputName}` is useable here and will point to the final wrapper derivation
 
       You may also call `require('nix-info')(defaultval, "path", "to", "item")`
 
@@ -83,13 +83,13 @@
     '';
   config.drv.buildPhase = ''
     runHook preBuild
-    { [ -e "$nixLuaInitPath" ] && cat "$nixLuaInitPath" || echo "$nixLuaInit"; } > ${lib.escapeShellArg "${placeholder "out"}/${config.binName}-rc.lua"}
+    { [ -e "$nixLuaInitPath" ] && cat "$nixLuaInitPath" || echo "$nixLuaInit"; } > ${lib.escapeShellArg "${placeholder config.outputName}/${config.binName}-rc.lua"}
     runHook postBuild
   '';
   config.flagSeparator = "=";
   config.flags = {
     "--config-file" = {
-      data = "${placeholder "out"}/${config.binName}-rc.lua";
+      data = "${placeholder config.outputName}/${config.binName}-rc.lua";
       esc-fn = lib.escapeShellArg;
     };
   };

--- a/wrapperModules/x/xplr/module.nix
+++ b/wrapperModules/x/xplr/module.nix
@@ -67,7 +67,7 @@ let
     else
       builtins.filter (v: v.enable) (wlib.dag.unwrapSort "xplr_init" config.luaInit);
   hasFnl = builtins.any (v: v.type == "fnl") initDal;
-  basePluginDir = "${placeholder "out"}/${config.binName}-plugins";
+  basePluginDir = "${placeholder config.outputName}/${config.binName}-plugins";
 in
 {
   imports = [ wlib.modules.default ];
@@ -261,7 +261,7 @@ in
       mkdir -p ${lib.escapeShellArg "${basePluginDir}"}
       { [ -e "$nixLuaInitPath" ] && cat "$nixLuaInitPath" || echo "$nixLuaInit"; }${
         if hasFnl then " | ${pkgs.luajitPackages.fennel}/bin/fennel --compile - " else " "
-      }> ${lib.escapeShellArg "${placeholder "out"}/${config.binName}-rc.lua"}
+      }> ${lib.escapeShellArg "${placeholder config.outputName}/${config.binName}-rc.lua"}
       { [ -e "$nixLuaInfoPath" ] && cat "$nixLuaInfoPath" || echo "$nixLuaInfo"; } > ${lib.escapeShellArg "${basePluginDir}/${config.infopath}.lua"}
       ${linkCommands}
       runHook postBuild
@@ -301,7 +301,7 @@ in
       name = "GENERATED_WRAPPER_LUA";
       data = [
         "-c"
-        "${placeholder "out"}/${config.binName}-rc.lua"
+        "${placeholder config.outputName}/${config.binName}-rc.lua"
       ];
       esc-fn = lib.escapeShellArg;
     }

--- a/wrapperModules/y/yt-dlp/module.nix
+++ b/wrapperModules/y/yt-dlp/module.nix
@@ -59,14 +59,14 @@ in
   config = {
     package = pkgs.yt-dlp;
     flags = {
-      "--config-location" = "${placeholder "out"}/${config.binName}-settings.conf";
+      "--config-location" = "${placeholder config.outputName}/${config.binName}-settings.conf";
     };
     drv = {
       renderedSettings = renderSettings config.settings;
       passAsFile = [ "renderedSettings" ];
       buildPhase = ''
         runHook preBuild
-        cp $renderedSettingsPath "$out/${config.binName}-settings.conf"
+        cp $renderedSettingsPath "${placeholder config.outputName}/${config.binName}-settings.conf"
         runHook postBuild
       '';
     };


### PR DESCRIPTION
Support for multiple derivation outputs, along with refactored path handling for wrapperFunction implementations (no longer need to build the path yourself)

 Key Changes

 1. Added outputName option (lib/core.nix, and wrapper variants)
    - Allows wrapper outputs to go to derivation outputs other than "out"
    - Each wrapper variant can specify its own outputName
    - Setting it in the core module will also set it as the default output (unfortunately, nix build will still build .out by default, no matter what the order of the outputs list is or the value of outputName is)

 2. Added wrapperPaths read-only options (lib/core.nix and wrapper variants)
    - input: The path to wrap
    - placeholder: The output path for the wrapper
    - relPath / relDir: Relative path components, (includes leading `/`)
    - Provides processed paths available to modules

 3. Updated wrapper implementations
    - lib/makeWrapper/makeWrapper.nix and makeWrapperNix.nix
    - wrapperModules/n/neovim/makeWrapper/*
    - All now use wrapperPaths.input and wrapperPaths.placeholder

 4. Updated symlinkScript module (modules/symlinkScript/module.nix)
    - Uses placeholder outputName instead of hardcoded $out

5. Neovim-specific updates (wrapperModules/n/neovim/*)
    - Each host can now have its own outputName and binDir
    - Uses new wrapperPaths for path resolution
    
A lot of places were changed from `${placeholder "out"}` to `${placeholder config.outputName}` that were not strictly necessary to change, for consistency purposes.