### PR TITLE
fix(modules.makeWrapper): Allow functions in select dag and dal types

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -245,6 +245,7 @@
     used by `wlib.modules.makeWrapper`
   */
   dalWithEsc = wlib.types.dalOf // {
+    dontConvertFunctions = true;
     modules = [
       {
         options.esc-fn = lib.mkOption {
@@ -266,6 +267,7 @@
     used by `wlib.modules.makeWrapper`
   */
   dagWithEsc = wlib.types.dagOf // {
+    dontConvertFunctions = true;
     inherit (wlib.types.dalWithEsc) modules;
   };
 

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -275,6 +275,7 @@ let
           (
             wlib.types.dagOf
             // {
+              dontConvertFunctions = true;
               modules = wlib.types.dagWithEsc.modules ++ [
                 {
                   options.sep = lib.mkOption {

--- a/wrapperModules/n/neovim/module.nix
+++ b/wrapperModules/n/neovim/module.nix
@@ -295,6 +295,7 @@ in
             parentOpts = null;
             parentName = null;
           };
+          dontConvertFunctions = true;
           modules =
             let
               inherit (config) specMods;
@@ -324,6 +325,7 @@ in
                               parentOpts = options;
                               parentName = name;
                             };
+                            dontConvertFunctions = true;
                             modules = [
                               {
                                 options.data = lib.mkOption {


### PR DESCRIPTION
Because functions are not valid main fields for these items, don't convert functions. This allows function-form submodules to be passed to them as well, which may be useful and/or nice.