### PR TITLE
fix(wlib.ignoreSpecField): dag entries must be valid dag entries

### DIFF
--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -74,7 +74,7 @@ let
       class = settings.class or null;
       description = settings.description or null;
       mainField = settings.mainField or null;
-      dontConvertFunctions = settings.dontConvertFunctions or false;
+      dontConvertFunctions = settings.dontConvertFunctions or null;
       modules =
         optionals (!isStrict) [ { freeformType = wlib.types.attrsRecursive; } ]
         ++ [
@@ -113,7 +113,7 @@ in
     - If `elemType` is a `submodule` or `spec`, a `parentName` argument will automatically be injected to access the actual attribute name.
   */
   dagWith =
-    settings: elemType: types.attrsOf (mkDagEntryModule (settings // { isDal = true; }) elemType);
+    settings: elemType: types.attrsOf (mkDagEntryModule (settings // { isDal = false; }) elemType);
 
   /**
     Arguments:
@@ -137,7 +137,7 @@ in
     - If `elemType` is a `submodule` or `spec`, a `parentName` argument will automatically be injected to access the actual attribute name.
   */
   dalWith =
-    settings: elemType: types.listOf (mkDagEntryModule (settings // { isDal = false; }) elemType);
+    settings: elemType: types.listOf (mkDagEntryModule (settings // { isDal = true; }) elemType);
 
   /**
     Arguments:

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -519,4 +519,47 @@ in
         result
     );
 
+  /**
+    Placeholder value used when overriding a non-main field of a spec type.
+
+    When overriding the main field of a spec type, things work as you might expect.
+
+    ```nix
+    # assuming these were already set in another module:
+
+    config.env.SOME_ALIAS.data = lib.mkForce "SOME OTHER VALUE";
+
+    config.env.ANOTHER_ALIAS = {
+      data = lib.mkForce "SOME OTHER VALUE";
+      after = [ "SOME_ALIAS" ];
+    };
+    ```
+
+    However, overriding ONLY an auxiliary field is slightly more challenging.
+
+    Each value provided to a spec type MUST be valid, or it is converted.
+
+    But without the main field defined, it is not a valid spec.
+
+    To prevent this, we must explicitly ignore the main field.
+
+    Example (overriding a non-main field):
+    ```nix
+    config.env.SOME_ALIAS = {
+      after = [ "OTHER_ALIAS" ];
+      data = wlib.ignoreSpecField;
+    };
+    ```
+
+    However, for the case of the `env` option, it accepts function submodules.
+
+    If the spec type has `dontConvertFunctions = true`, like `env` does,
+    then you can do this instead.
+
+    ```nix
+    config.env.SOME_ALIAS = { ... }: { after = [ "OTHER_ALIAS" ]; };
+    ```
+  */
+  ignoreSpecField = lib.mkIf false null;
+
 }

--- a/lib/specWith.nix
+++ b/lib/specWith.nix
@@ -13,7 +13,7 @@ let
       class ? null,
       description ? null,
       mainField ? null,
-      dontConvertFunctions ? false,
+      dontConvertFunctions ? null,
     }@attrs:
     let
       inherit (builtins)
@@ -82,7 +82,7 @@ let
       # returns true if already the submodule type and false if not
       checkMergeDef =
         def:
-        if dontConvertFunctions && isFunction def.value then
+        if builtins.isBool dontConvertFunctions && dontConvertFunctions && isFunction def.value then
           true
         else if baseNoCheck._module.freeformType or null != null then
           isAttrs def.value && def.value ? "${toString main_field}"

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -245,6 +245,7 @@
     used by `wlib.modules.makeWrapper`
   */
   dalWithEsc = wlib.types.dalOf // {
+    dontConvertFunctions = true;
     modules = [
       {
         options.esc-fn = lib.mkOption {
@@ -266,6 +267,7 @@
     used by `wlib.modules.makeWrapper`
   */
   dagWithEsc = wlib.types.dagOf // {
+    dontConvertFunctions = true;
     inherit (wlib.types.dalWithEsc) modules;
   };
 

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -275,6 +275,7 @@ let
           (
             wlib.types.dagOf
             // {
+              dontConvertFunctions = true;
               modules = wlib.types.dagWithEsc.modules ++ [
                 {
                   options.sep = lib.mkOption {

--- a/wrapperModules/n/neovim/module.nix
+++ b/wrapperModules/n/neovim/module.nix
@@ -295,6 +295,7 @@ in
             parentOpts = null;
             parentName = null;
           };
+          dontConvertFunctions = true;
           modules =
             let
               inherit (config) specMods;
@@ -324,6 +325,7 @@ in
                               parentOpts = options;
                               parentName = name;
                             };
+                            dontConvertFunctions = true;
                             modules = [
                               {
                                 options.data = lib.mkOption {


### PR DESCRIPTION
this is a surprisingly non-trivial fact. If the item you are passing is not a valid dag entry, it will attempt to turn it into one.

If it is not a valid dag entry, you can use this to set the main field without really setting it.

Also some bugfixes, and most dags which did not previously accept function type submodules now do accept them

I should note that if you do one day figure out how to do it in a way that does not require `wlib.ignoreSpecField`, that update will be non-breaking. This is because it does nothing. And will continue to do nothing.