### PR TITLE
feat(modules.makeWrapper): allow null values in env and envDefault to remove entries

### DIFF
--- a/ci/checks/env-null.nix
+++ b/ci/checks/env-null.nix
@@ -1,0 +1,38 @@
+{
+  pkgs,
+  self,
+}:
+
+let
+  wrappedPackage = self.lib.wrapPackage {
+    inherit pkgs;
+    package = pkgs.hello;
+    env.MY_NULL_ENV = null;
+    envDefault.MY_NULL_DEFAULT = null;
+  };
+
+in
+pkgs.runCommand "env-null-test" { } ''
+  echo "Testing that null env and envDefault entries are omitted..."
+
+  wrapperScript="${wrappedPackage}/bin/hello"
+  if [ ! -f "$wrapperScript" ]; then
+    echo "FAIL: Wrapper script not found"
+    exit 1
+  fi
+
+  if grep -q "MY_NULL_ENV" "$wrapperScript"; then
+    echo "FAIL: MY_NULL_ENV should be omitted (value was null)"
+    cat "$wrapperScript"
+    exit 1
+  fi
+
+  if grep -q "MY_NULL_DEFAULT" "$wrapperScript"; then
+    echo "FAIL: MY_NULL_DEFAULT should be omitted (value was null)"
+    cat "$wrapperScript"
+    exit 1
+  fi
+
+  echo "SUCCESS: null env and envDefault entries correctly omitted"
+  touch $out
+''

--- a/lib/makeWrapper/default.nix
+++ b/lib/makeWrapper/default.nix
@@ -368,7 +368,9 @@ in
         ++ mapAndLiftDal "addFlag" (config.addFlag or [ ])
         ++ mapAndLiftDal "appendFlag" (config.appendFlag or [ ]);
     in
-    if sortResult then wlib.dag.unwrapSort "makeWrapper" unsorted else unsorted;
+    builtins.filter (v: !(v.type == "env" || v.type == "envDefault") || v.data or null != null) (
+      if sortResult then wlib.dag.unwrapSort "makeWrapper" unsorted else unsorted
+    );
 
   /*
     splitDal receives the dal as returned by `aggregateSingleOptionSet` and splits it into 2 lists, `args` and `other`.

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -408,7 +408,7 @@ let
           ];
         };
       options.${if !(excluded.env or false) then "env" else null} = lib.mkOption {
-        type = wlib.types.dagWithEsc wlib.types.stringable;
+        type = wlib.types.dagWithEsc (lib.types.nullOr wlib.types.stringable);
         default = if mainConfig != null && config.mirror or false then mainConfig.env else { };
         example = {
           "XDG_DATA_HOME" = "/somewhere/on/your/machine";
@@ -425,7 +425,7 @@ let
         '';
       };
       options.${if !(excluded.envDefault or false) then "envDefault" else null} = lib.mkOption {
-        type = wlib.types.dagWithEsc wlib.types.stringable;
+        type = wlib.types.dagWithEsc (lib.types.nullOr wlib.types.stringable);
         default = if mainConfig != null && config.mirror or false then mainConfig.envDefault else { };
         example = {
           "XDG_DATA_HOME" = "/only/if/not/set";


### PR DESCRIPTION
basically due to the fact that claude code is vibecoded slop (but slop that work pays for):

1. when new features are released, if `DISABLE_TELEMETRY` (defaults to "1" in the module here) is set, that gets in the way of them fetching some server-side config to _actually_ enable it for a given user
2. it doesn't check any actual VALUE of `DISABLE_TELEMETRY`. if i override `DISABLE_TELEMETRY` to equal "0", it still won't work (https://github.com/anthropics/claude-code/issues/33403#issuecomment-4043741041)

only option is to completely remove the `DISABLE_TELEMETRY` env var, which I dont believe is currently possible with the way its currently set up? or at least not that i could figure out

alternatively could just remove `DISABLE_TELEMETRY` from claude code's `envDefault` but idk I felt weird being the one to magically change telemetry from being off by default to on by default (if anyone other than me even uses that module)

this tries to basically make it just work the same as `flags`