### PR TITLE
fix(wrapperModules.neovim): import wlib.modules.constructFiles

### DIFF
--- a/wrapperModules/n/neovim/module.nix
+++ b/wrapperModules/n/neovim/module.nix
@@ -181,6 +181,7 @@ in
         wrapperFunction = import ./makeWrapper;
       }
     )
+    wlib.modules.constructFiles
     ./packDir.nix
     ./default-config.nix
   ];


### PR DESCRIPTION
It was not imported in wrapperModules.neovim, but there was no reason not to import it.