### PR TITLE
fix(wlib.dag.specsBetween): not enough info to ensure proper ordering

### DIFF
--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -533,11 +533,11 @@ in
           }
         else
           {
-            ${name} = specAfter after current // {
+            ${name} = specBetween before after current // {
               inherit name;
             };
           }
-          // go (i + 1) before [ name ] (tail entries);
+          // go (i + 1) before (after ++ [ name ]) (tail entries);
     in
     go 0;
 


### PR DESCRIPTION
Nope. This is dumb.