### PR TITLE
feat(lib.types.lazyAttrsRecursive): and make config.passthru use it

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -377,12 +377,21 @@ in
       '';
     };
     passthru = lib.mkOption {
-      type = wlib.types.attrsRecursive;
+      type = wlib.types.lazyAttrsRecursive;
       default = { };
       description = ''
         Additional attributes to add to the resulting derivation's passthru.
         This can be used to add additional metadata or functionality to the wrapped package.
         Anything added under the attribute name `configuration` will be ignored, as that value is used internally.
+
+        This uses `wlib.types.lazyAttrsRecursive` to support lazy evaluation of the attributes,
+        as is often desired of passthru values.
+
+        This means that you cannot `config.passthru.somevalue = lib.mkIf condition "some value";`
+
+        But as a result, you can `config.passthru.somevalue = "''${config.wrapper}/some/path";`
+
+        To achieve an optional value, use `config.passthru = lib.optionalAttrs { somevalue = "some value"; };`
       '';
     };
     drv = lib.mkOption {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -2,6 +2,54 @@
   wlib,
   lib,
 }:
+let
+  attrsRecursive =
+    lazy:
+    lib.mkOptionType {
+      name = "attrsRecursive";
+      description = "attrsRecursive";
+      descriptionClass = "noun";
+      check = value: true;
+      merge =
+        loc: defs:
+        let
+          getType =
+            value:
+            if lib.isAttrs value && lib.isStringLike value then "stringCoercibleSet" else builtins.typeOf value;
+
+          # Returns the common type of all definitions, throws an error if they
+          # don't have the same type
+          commonType = lib.foldl' (
+            type: def:
+            if getType def.value == type then
+              type
+            else
+              throw "The option `${lib.showOption loc}' has conflicting option types in ${lib.showFiles (lib.getFiles defs)}"
+          ) (getType (lib.head defs).value) defs;
+
+          mergeFunction =
+            {
+              # Recursively merge attribute sets
+              set = ((if lazy then lib.types.lazyAttrsOf else lib.types.attrsOf) wlib.types.attrsRecursive).merge;
+              # merge lists
+              list = (lib.types.listOf wlib.types.attrsRecursive).merge;
+              # This is the type of packages, only accept a single definition
+              stringCoercibleSet = lib.mergeOneOption;
+              lambda =
+                loc: defs: arg:
+                wlib.types.attrsRecursive.merge (loc ++ [ "<function body>" ]) (
+                  map (def: {
+                    file = def.file;
+                    value = def.value arg;
+                  }) defs
+                );
+              # Otherwise fall back to only allowing all equal definitions
+            }
+            .${commonType} or lib.mergeEqualOption;
+        in
+        mergeFunction loc defs;
+    };
+in
 {
 
   /**
@@ -410,48 +458,10 @@
   /**
     Like `lib.types.anything`, but allows contained lists to also be merged
   */
-  attrsRecursive = lib.mkOptionType {
-    name = "attrsRecursive";
-    description = "attrsRecursive";
-    descriptionClass = "noun";
-    check = value: true;
-    merge =
-      loc: defs:
-      let
-        getType =
-          value:
-          if lib.isAttrs value && lib.isStringLike value then "stringCoercibleSet" else builtins.typeOf value;
+  attrsRecursive = attrsRecursive false;
 
-        # Returns the common type of all definitions, throws an error if they
-        # don't have the same type
-        commonType = lib.foldl' (
-          type: def:
-          if getType def.value == type then
-            type
-          else
-            throw "The option `${lib.showOption loc}' has conflicting option types in ${lib.showFiles (lib.getFiles defs)}"
-        ) (getType (lib.head defs).value) defs;
-
-        mergeFunction =
-          {
-            # Recursively merge attribute sets
-            set = (lib.types.attrsOf wlib.types.attrsRecursive).merge;
-            # merge lists
-            list = (lib.types.listOf wlib.types.attrsRecursive).merge;
-            # This is the type of packages, only accept a single definition
-            stringCoercibleSet = lib.mergeOneOption;
-            lambda =
-              loc: defs: arg:
-              wlib.types.attrsRecursive.merge (loc ++ [ "<function body>" ]) (
-                map (def: {
-                  file = def.file;
-                  value = def.value arg;
-                }) defs
-              );
-            # Otherwise fall back to only allowing all equal definitions
-          }
-          .${commonType} or lib.mergeEqualOption;
-      in
-      mergeFunction loc defs;
-  };
+  /**
+    Like `wlib.types.attrsRecursive`, but uses `lib.types.lazyAttrsOf` instead.
+  */
+  lazyAttrsRecursive = attrsRecursive true;
 }

--- a/wrapperModules/z/zsh/module.nix
+++ b/wrapperModules/z/zsh/module.nix
@@ -104,20 +104,8 @@ in
   config.package = lib.mkDefault pkgs.zsh;
   # Allow use as a system/user shell
   config.passthru.shellPath = config.wrapperPaths.relPath;
+  config.passthru.ZDOTDIR = "${config.wrapper.${config.zdotFilesOutput}}/${config.zdotFilesDirname}";
   config.flags."-d" = config.skipGlobalRC;
-  # I think I can't just add this to passthru because passthru is not read only
-  # It worked so well for constructFiles that I just expected that to work too.
-  config.builderFunction = lib.mkDefault (
-    { buildCommand, ... }:
-    args:
-    args
-    // {
-      inherit buildCommand;
-      passthru = args.passthru // {
-        ZDOTDIR = "${config.wrapper.${config.zdotFilesOutput}}/${config.zdotFilesDirname}";
-      };
-    }
-  );
   config.meta.maintainers = [
     wlib.maintainers.fluxza
     wlib.maintainers.birdee


### PR DESCRIPTION
This lets you pass stuff to things within the wrapper to things outside of the wrapper by passing things with `config.wrapper` in them via `config.passthru`