### PR TITLE
fix(wrapperModules.zsh): prefix and suffix path would stack

### DIFF
--- a/wrapperModules/z/zsh/zshenv.nix
+++ b/wrapperModules/z/zsh/zshenv.nix
@@ -102,8 +102,8 @@ let
     let
       setvarfunc = /* zsh */ ''wrapperSetEnv() { export "$1=$2"; }'';
       setvardefaultfunc = /* zsh */ ''wrapperSetEnvDefault() { [ -z "''${(P)1+x}" ] && export "$1=$2"; }'';
-      prefixvarfunc = /* zsh */ ''wrapperPrefixEnv() { export "$1=''${(P)1:+$3$2}''${(P)1:-$3}"; }'';
-      suffixvarfunc = /* zsh */ ''wrapperSuffixEnv() { export "$1=''${(P)1:+''${(P)1}$2}$3"; }'';
+      prefixvarfunc = /* zsh */ ''wrapperPrefixEnv() { [[ "''${(P)1}" != "$3$2"* ]] && export "$1=''${(P)1:+$3$2}''${(P)1:-$3}"; }'';
+      suffixvarfunc = /* zsh */ ''wrapperSuffixEnv() { [[ "''${(P)1}" != *"$2$3"* ]] && export "$1=''${(P)1:+''${(P)1}$2}$3"; }'';
     in
     builtins.concatStringsSep "\n" (
       lib.optional (config.env or { } != { }) setvarfunc


### PR DESCRIPTION
now only reapplies if it is no longer the prefix, or the suffixed value is not present