### PR TITLE
fix: zathura "options" option -> "settings" option

### DIFF
--- a/wrapperModules/z/zathura/module.nix
+++ b/wrapperModules/z/zathura/module.nix
@@ -29,7 +29,7 @@ in
         ]);
       default = { };
       internal = true;
-      apply = x: if x != { } then lib.warn "'options' has been renamed to 'settings'" else x;
+      apply = x: if x != { } then lib.warn "nix-wrapper-modules zathura: 'options' has been renamed to 'settings'" else x;
     };
     settings = lib.mkOption {
       type =


### PR DESCRIPTION
"options" option confuses with module-making option rather than a module option