### PR TITLE
fix(placeholders): (breaking) fix placeholders in more modules

### DIFF
--- a/wrapperModules/n/niri/module.nix
+++ b/wrapperModules/n/niri/module.nix
@@ -233,9 +233,50 @@ in
         };
       };
     };
-    "config.kdl" =
-      let
-        compiledConfig = lib.strings.concatLines (
+    "config.kdl" = lib.mkOption {
+      type = wlib.types.file pkgs;
+      default.path = config.constructFiles.generatedConfig.path;
+      default.content = "";
+      description = ''
+        Configuration file for Niri.
+        See <https://github.com/YaLTeR/niri/wiki/Configuration:-Introduction>
+      '';
+      example = ''
+        input {
+          keyboard {
+              numlock
+          }
+
+          touchpad {
+              tap
+              natural-scroll
+          }
+
+          focus-follows-mouse = {
+            _attrs = { max-scroll-amount = "0%"; };
+          };
+        }
+      '';
+    };
+  };
+  config.filesToPatch = [
+    "share/applications/*.desktop"
+    "share/systemd/user/niri.service"
+  ];
+  config.drv.installPhase = ''
+    runHook preInstall
+    ${lib.getExe config.package} validate -c ${config.constructFiles.generatedConfig.path}
+    runHook postInstall
+  '';
+  config.package = pkgs.niri;
+  config.env.NIRI_CONFIG = config."config.kdl".path;
+  config.constructFiles.generatedConfig = {
+    relPath = "${config.binName}-config.json";
+    content =
+      if config."config.kdl".content or "" != "" then
+        config."config.kdl".content
+      else
+        lib.strings.concatLines (
           lib.lists.flatten [
             # (attrsToKdl { inherit (config.settings) binds layout; })
             (map (mkRule "window-rule") config.settings.window-rules)
@@ -265,46 +306,6 @@ in
             config.settings.extraConfig
           ]
         );
-        checkedConfig = pkgs.writeTextFile {
-          name = "niri.kdl";
-          text = compiledConfig;
-          checkPhase = ''
-            ${lib.getExe config.package} validate -c $out
-          '';
-        };
-      in
-      lib.mkOption {
-        type = wlib.types.file pkgs;
-        default.path = checkedConfig;
-        description = ''
-          Configuration file for Niri.
-          See <https://github.com/YaLTeR/niri/wiki/Configuration:-Introduction>
-        '';
-        example = ''
-          input {
-            keyboard {
-                numlock
-            }
-
-            touchpad {
-                tap
-                natural-scroll
-            }
-
-            focus-follows-mouse = {
-              _attrs = { max-scroll-amount = "0%"; };
-            };
-          }
-        '';
-      };
-  };
-  config.filesToPatch = [
-    "share/applications/*.desktop"
-    "share/systemd/user/niri.service"
-  ];
-  config.package = pkgs.niri;
-  config.env = {
-    NIRI_CONFIG = toString config."config.kdl".path;
   };
   config.meta.maintainers = [
     wlib.maintainers.patwid

--- a/wrapperModules/n/nushell/module.nix
+++ b/wrapperModules/n/nushell/module.nix
@@ -11,6 +11,7 @@
     "env.nu" = lib.mkOption {
       type = wlib.types.file pkgs;
       default.content = "";
+      default.path = config.constructFiles.generatedEnv.path;
       description = ''
         The Nushell environment configuration file.
 
@@ -22,6 +23,7 @@
     "config.nu" = lib.mkOption {
       type = wlib.types.file pkgs;
       default.content = "";
+      default.path = config.constructFiles.generatedConfig.path;
       description = ''
         The main Nushell configuration file.
 
@@ -36,6 +38,14 @@
   config.flags = {
     "--config" = config."config.nu".path;
     "--env-config" = config."env.nu".path;
+  };
+  config.constructFiles.generatedConfig = {
+    content = config."config.nu".content;
+    relPath = "${config.binName}-config/config.nu";
+  };
+  config.constructFiles.generatedEnv = {
+    content = config."env.nu".content;
+    relPath = "${config.binName}-config/env.nu";
   };
   config.passthru.shellPath = "/bin/nu";
 

--- a/wrapperModules/o/opencode/module.nix
+++ b/wrapperModules/o/opencode/module.nix
@@ -15,8 +15,10 @@
   config = {
     meta.maintainers = [ wlib.maintainers.birdee ];
     package = lib.mkDefault pkgs.opencode;
-    envDefault = {
-      OPENCODE_CONFIG = pkgs.writeText "OPENCODE_CONFIG.json" (builtins.toJSON config.settings);
+    envDefault.OPENCODE_CONFIG = config.constructFiles.generatedConfig.path;
+    constructFiles.generatedConfig = {
+      relPath = "${config.binName}-config.json";
+      content = builtins.toJSON config.settings;
     };
   };
 }

--- a/wrapperModules/o/ov/module.nix
+++ b/wrapperModules/o/ov/module.nix
@@ -21,7 +21,12 @@ in
     };
   };
   config.flags = {
-    "--config" = yamlFmt.generate "ov.yaml" config.settings;
+    "--config" = config.constructFiles.generatedConfig.path;
+  };
+  config.constructFiles.generatedConfig = {
+    content = builtins.toJSON config.settings;
+    relPath = "${config.binName}-config.yaml";
+    builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2yaml "$1" "$2"'';
   };
   config.package = lib.mkDefault pkgs.ov;
   config.meta.maintainers = [ wlib.maintainers.rencire ];


### PR DESCRIPTION
placeholders are now usable in all options for `niri`, `opencode`, `nushell`, and `ov`

Same benefits and drawbacks as the last 2 commits, (This PR https://github.com/BirdeeHub/nix-wrapper-modules/pull/367) just for more modules

From outside of the module, grab the path via `config.constructFiles.generatedConfig.outPath`

Still to go:

`rofi`, `waybar`, `claude-code`, `btop` and `mpv` modules

After that, everything that could reasonably support it will have this capability