### PR TITLE
fix(wrapperModules.helix): regression for generated settings file

### DIFF
--- a/wrapperModules/h/helix/module.nix
+++ b/wrapperModules/h/helix/module.nix
@@ -87,7 +87,7 @@ in
   config.drv.extraSettings = config.extraSettings;
   config.drv.passAsFile = [ "extraSettings" ];
   config.constructFiles = {
-    config = lib.mkIf (config.settings != { } && config.extraSettings != "") {
+    config = lib.mkIf (config.settings != { } || config.extraSettings != "") {
       relPath = lib.mkOverride 0 "${config.binName}-config/helix/config.toml";
       output = lib.mkOverride 0 config.generatedConfig.output;
       content = builtins.toJSON config.settings;


### PR DESCRIPTION
addresses https://github.com/BirdeeHub/nix-wrapper-modules/issues/372