### PR TITLE
feat(wrapperModules.mpv): use --config-dir instead of separate flags for each file

### DIFF
--- a/wrapperModules/m/mpv/check.nix
+++ b/wrapperModules/m/mpv/check.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  mpvWrapped =
+  mpvWithoutConfigDirectory =
     (self.wrappers.mpv.apply {
       inherit pkgs;
       scripts = [
@@ -15,19 +15,53 @@ let
         vo=null
       '';
     }).wrapper;
+  mpvWithConfigDirectory =
+    (self.wrappers.mpv.apply {
+      inherit pkgs;
+      scripts = [
+        pkgs.mpvScripts.visualizer
+      ];
+      scriptFiles = {
+        "script-opts/visualizer.conf" = ''
+          mode="force"
+        '';
+      };
+      "mpv.conf".content = ''
+        ao=null
+        vo=null
+      '';
+    }).wrapper;
 in
 pkgs.runCommand "mpv-test" { } ''
-  res="$(${mpvWrapped}/bin/mpv --version)"
+  res="$(${mpvWithoutConfigDirectory}/bin/mpv --version)"
   if ! echo "$res" | grep "mpv"; then
     echo "failed to run wrapped package!"
-    echo "wrapper content for ${mpvWrapped}/bin/mpv"
-    cat "${mpvWrapped}/bin/mpv"
+    echo "wrapper content for ${mpvWithoutConfigDirectory}/bin/mpv"
+    cat "${mpvWithoutConfigDirectory}/bin/mpv"
     exit 1
   fi
-  if ! cat "${mpvWrapped.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F "share/mpv/scripts/visualizer.lua"; then
+  if ! cat "${mpvWithoutConfigDirectory.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F "share/mpv/scripts/visualizer.lua"; then
     echo "failed to find added script when inspecting overriden package value"
-    echo "overriden package value ${mpvWrapped.configuration.package}/bin/mpv"
-    cat "${mpvWrapped.configuration.package}/bin/mpv"
+    echo "overriden package value ${mpvWithoutConfigDirectory.configuration.package}/bin/mpv"
+    cat "${mpvWithoutConfigDirectory.configuration.package}/bin/mpv"
+    exit 1
+  fi
+
+  res="$(${mpvWithConfigDirectory}/bin/mpv --version)"
+  if ! echo "$res" | grep "mpv"; then
+    echo "failed to run wrapped package with config directory!"
+    echo "wrapper content for ${mpvWithConfigDirectory}/bin/mpv"
+    cat "${mpvWithConfigDirectory}/bin/mpv"
+    exit 1
+  fi
+  if ! cat "${mpvWithConfigDirectory.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F "share/mpv/scripts/visualizer.lua"; then
+    echo "failed to find added script when inspecting overriden package value with config directory"
+    echo "overriden package value ${mpvWithConfigDirectory.configuration.package}/bin/mpv"
+    cat "${mpvWithConfigDirectory.configuration.package}/bin/mpv"
+    exit 1
+  fi
+  if ! grep -q "force" "${mpvWithConfigDirectory}/mpv-config/script-opts/visualizer.conf"; then
+    echo "failed to read script options from config directory"
     exit 1
   fi
   touch $out

--- a/wrapperModules/m/mpv/module.nix
+++ b/wrapperModules/m/mpv/module.nix
@@ -19,6 +19,28 @@
         These are appended to MPV’s build with `pkgs.mpv.override`.
       '';
     };
+    scriptFiles = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = ''
+        Additional files to be included in the MPV config directory.
+
+        By using this option, mpv will no longer look for script-opts in the default
+        $XDG_CONFIG_HOME/mpv/script-opts location, and all additional files will have
+        to be specified in this option.
+
+        Each entry of the attrset is the relative path to the file and their content respectively.
+      '';
+      example = lib.literalMD ''
+        ```nix
+        {
+          "script-opts/modernz.conf" = '''
+            window_top_bar=no
+            seekbarfg_color=#FFFFFF
+          ''';
+        };
+      '';
+    };
     "mpv.input" = lib.mkOption {
       type = wlib.types.file pkgs;
       default.path = config.constructFiles.generatedInput.path;
@@ -44,19 +66,39 @@
       '';
     };
   };
+
   config.flagSeparator = "=";
-  config.flags = {
-    "--input-conf" = config."mpv.input".path;
-    "--include" = config."mpv.conf".path;
-  };
-  config.constructFiles.generatedConfig = {
-    relPath = "${config.binName}-config/mpv.conf";
-    content = config."mpv.conf".content;
-  };
-  config.constructFiles.generatedInput = {
-    relPath = "${config.binName}-config/mpv.input";
-    content = config."mpv.input".content;
-  };
+  config.flags =
+    if config.scriptFiles == { } then
+      {
+        "--config-dir" = "${placeholder config.outputName}/${config.binName}-config";
+      }
+    else
+      {
+        "--input-conf" = config."mpv.input".path;
+        "--include" = config."mpv.conf".path;
+      };
+
+  config.constructFiles = (
+    {
+      generatedConfig = {
+        relPath = "${config.binName}-config/mpv.conf";
+        content = config."mpv.conf".content;
+      };
+      generatedInput = {
+        relPath = "${config.binName}-config/input.conf";
+        content = config."mpv.input".content;
+      };
+    }
+    // (lib.mapAttrs' (
+      relPath: content:
+      lib.nameValuePair relPath {
+        inherit content;
+        relPath = "${config.binName}-config/${relPath}";
+      }
+    ) config.scriptFiles)
+  );
+
   config.overrides = [
     {
       name = "MPV_SCRIPTS";


### PR DESCRIPTION
Currently the module uses separate `--include` and `--input-conf` flags. While this works, it makes it very awkward to extend this module to write additional files such as script-opts settings. (The --script-opts flag is used to pass a long string of script-opt settings, instead of pointing to a script-opt directory: https://mpv.io/manual/stable/#options-script-opt) 

Switching it to use the `--config-dir` option will allow being able to write other files into the already created `mpv-config` directory and still have those work. This change is internal and does not affect functionality for existing users.