### PR TITLE
feat(wrapperModules.mpv): expand script and config options

### DIFF
--- a/wrapperModules/m/mpv/check.nix
+++ b/wrapperModules/m/mpv/check.nix
@@ -4,30 +4,164 @@
 }:
 
 let
-  mpvWrapped =
-    (self.wrappers.mpv.apply {
-      inherit pkgs;
-      scripts = [
-        pkgs.mpvScripts.visualizer
-      ];
-      "mpv.conf".content = ''
-        ao=null
-        vo=null
+  mpvWithPkgs = self.wrappers.mpv.apply { inherit pkgs; };
+  mpvWithoutConfigDirectory = mpvWithPkgs.wrap {
+    script.visualizer.path = pkgs.mpvScripts.visualizer;
+    "mpv.conf".content = ''
+      ao=null
+      vo=null
+    '';
+  };
+  mpvWithConfigDirectory = mpvWithPkgs.wrap {
+    script.visualizer.path = pkgs.mpvScripts.visualizer;
+    configDir = {
+      "script-opts/visualizer.conf".content = ''
+        mode="force"
       '';
-    }).wrapper;
+    };
+    "mpv.conf".content = ''
+      ao=null
+      vo=null
+    '';
+  };
+  mpvWithScriptOptsAppend = mpvWithPkgs.wrap {
+    script = {
+      "visualizer.lua" = {
+        path = pkgs.mpvScripts.visualizer;
+        opts = {
+          mode = "force";
+          custom_opt = "test_value";
+        };
+      };
+    };
+    "mpv.conf".content = ''
+      ao=null
+      vo=null
+    '';
+  };
+  mpvWithScriptPath = mpvWithPkgs.wrap {
+    script = {
+      "my-script.lua" = {
+        path = pkgs.mpvScripts.visualizer + "/share/mpv/scripts/visualizer.lua";
+        opts = {
+          mode = "force";
+        };
+      };
+    };
+    "mpv.conf".content = ''
+      ao=null
+      vo=null
+    '';
+  };
+  mpvWithNixpkgsScriptViaPath = mpvWithPkgs.wrap {
+    script = {
+      visualizer = {
+        path = pkgs.mpvScripts.visualizer;
+        opts = {
+          mode = "force";
+        };
+      };
+    };
+    "mpv.conf".content = ''
+      ao=null
+      vo=null
+    '';
+  };
 in
 pkgs.runCommand "mpv-test" { } ''
-  res="$(${mpvWrapped}/bin/mpv --version)"
+  res="$(${mpvWithoutConfigDirectory}/bin/mpv --version)"
   if ! echo "$res" | grep "mpv"; then
     echo "failed to run wrapped package!"
-    echo "wrapper content for ${mpvWrapped}/bin/mpv"
-    cat "${mpvWrapped}/bin/mpv"
+    echo "wrapper content for ${mpvWithoutConfigDirectory}/bin/mpv"
+    cat "${mpvWithoutConfigDirectory}/bin/mpv"
     exit 1
   fi
-  if ! cat "${mpvWrapped.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F "share/mpv/scripts/visualizer.lua"; then
+  if ! cat "${mpvWithoutConfigDirectory.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F "share/mpv/scripts/visualizer.lua"; then
     echo "failed to find added script when inspecting overriden package value"
-    echo "overriden package value ${mpvWrapped.configuration.package}/bin/mpv"
-    cat "${mpvWrapped.configuration.package}/bin/mpv"
+    echo "overriden package value ${mpvWithoutConfigDirectory.configuration.package}/bin/mpv"
+    cat "${mpvWithoutConfigDirectory.configuration.package}/bin/mpv"
+    exit 1
+  fi
+
+  res="$(${mpvWithConfigDirectory}/bin/mpv --version)"
+  if ! echo "$res" | grep "mpv"; then
+    echo "failed to run wrapped package with config directory!"
+    echo "wrapper content for ${mpvWithConfigDirectory}/bin/mpv"
+    cat "${mpvWithConfigDirectory}/bin/mpv"
+    exit 1
+  fi
+  if ! cat "${mpvWithConfigDirectory.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F "share/mpv/scripts/visualizer.lua"; then
+    echo "failed to find added script when inspecting overriden package value with config directory"
+    echo "overriden package value ${mpvWithConfigDirectory.configuration.package}/bin/mpv"
+    cat "${mpvWithConfigDirectory.configuration.package}/bin/mpv"
+    exit 1
+  fi
+  if ! grep -q "force" "${mpvWithConfigDirectory}/mpv-config/script-opts/visualizer.conf"; then
+    echo "failed to read script options from config directory"
+    exit 1
+  fi
+
+  res="$(${mpvWithScriptOptsAppend}/bin/mpv --version)"
+  if ! echo "$res" | grep "mpv"; then
+    echo "failed to run wrapped package with script-opts-append!"
+    echo "wrapper content for ${mpvWithScriptOptsAppend}/bin/mpv"
+    cat "${mpvWithScriptOptsAppend}/bin/mpv"
+    exit 1
+  fi
+  if ! grep -q "script-opts-append" "${mpvWithScriptOptsAppend}/bin/mpv"; then
+    echo "failed to find --script-opts-append flag in wrapper"
+    cat "${mpvWithScriptOptsAppend}/bin/mpv"
+    exit 1
+  fi
+  if ! grep -q "visualizer-mode=force" "${mpvWithScriptOptsAppend}/bin/mpv"; then
+    echo "failed to find visualizer_mode=force in --script-opts-append"
+    cat "${mpvWithScriptOptsAppend}/bin/mpv"
+    exit 1
+  fi
+  if ! grep -q "visualizer-custom_opt=test_value" "${mpvWithScriptOptsAppend}/bin/mpv"; then
+    echo "failed to find visualizer_custom_opt=test_value in --script-opts-append"
+    cat "${mpvWithScriptOptsAppend}/bin/mpv"
+    exit 1
+  fi
+
+  res="$(${mpvWithScriptPath}/bin/mpv --version)"
+  if ! echo "$res" | grep "mpv"; then
+    echo "failed to run wrapped package with script path!"
+    echo "wrapper content for ${mpvWithScriptPath}/bin/mpv"
+    cat "${mpvWithScriptPath}/bin/mpv"
+    exit 1
+  fi
+  if ! grep -q "scripts-append" "${mpvWithScriptPath}/bin/mpv"; then
+    echo "failed to find --scripts-append flag in wrapper with path"
+    cat "${mpvWithScriptPath}/bin/mpv"
+    exit 1
+  fi
+  if ! grep -q "my_script-mode=force" "${mpvWithScriptPath}/bin/mpv"; then
+    echo "failed to find my_script-mode=force in --script-opts-append with path"
+    cat "${mpvWithScriptPath}/bin/mpv"
+    exit 1
+  fi
+
+  res="$(${mpvWithNixpkgsScriptViaPath}/bin/mpv --version)"
+  if ! echo "$res" | grep "mpv"; then
+    echo "failed to run wrapped package with nixpkgs script via path!"
+    echo "wrapper content for ${mpvWithNixpkgsScriptViaPath}/bin/mpv"
+    cat "${mpvWithNixpkgsScriptViaPath}/bin/mpv"
+    exit 1
+  fi
+  if grep -q "scripts-append" "${mpvWithNixpkgsScriptViaPath}/bin/mpv"; then
+    echo "FAIL: nixpkgs script should NOT use --scripts-append"
+    cat "${mpvWithNixpkgsScriptViaPath}/bin/mpv"
+    exit 1
+  fi
+  if ! cat "${mpvWithNixpkgsScriptViaPath.configuration.package}/bin/mpv" | LC_ALL=C grep -a -F "share/mpv/scripts/visualizer.lua"; then
+    echo "FAIL: nixpkgs script should be in override (package bin/mpv)"
+    cat "${mpvWithNixpkgsScriptViaPath.configuration.package}/bin/mpv"
+    exit 1
+  fi
+  if ! grep -q "visualizer-mode=force" "${mpvWithNixpkgsScriptViaPath}/bin/mpv"; then
+    echo "FAIL: nixpkgs script opts should still use --script-opts-append"
+    cat "${mpvWithNixpkgsScriptViaPath}/bin/mpv"
     exit 1
   fi
   touch $out

--- a/wrapperModules/m/mpv/module.nix
+++ b/wrapperModules/m/mpv/module.nix
@@ -5,18 +5,156 @@
   pkgs,
   ...
 }:
+let
+  removeExt =
+    s:
+    let
+      m = builtins.match "^(.*)\\.[^.]*$" s;
+    in
+    if m == null then s else builtins.elemAt m 0;
+  isAlphaNum =
+    v:
+    let
+      isUpper = c: c >= "A" && c <= "Z";
+      isLower = c: c >= "a" && c <= "z";
+      isDigit = c: c >= "0" && c <= "9";
+    in
+    isUpper v || isLower v || isDigit v || v == "_";
+  sanitizeScriptName = lib.flip lib.pipe [
+    baseNameOf
+    removeExt
+    lib.stringToCharacters
+    (map (v: if isAlphaNum v then v else "_"))
+    (builtins.concatStringsSep "")
+  ];
+
+  partitionAttrs =
+    pred: attrs:
+    lib.pipe attrs [
+      (lib.mapAttrsToList lib.nameValuePair)
+      (lib.partition (v: pred v.name v.value))
+      (
+        { right, wrong }:
+        {
+          right = builtins.listToAttrs right;
+          wrong = builtins.listToAttrs wrong;
+        }
+      )
+    ];
+
+  partitioned =
+    let
+      partitioned = partitionAttrs (name: v: builtins.isString (v.path.passthru.scriptName or null)) (
+        lib.filterAttrs (n: v: v.enable) config.script
+      );
+    in
+    {
+      nixpkgsScripts = lib.mapAttrsToList (n: v: v.path) partitioned.right;
+      userScripts = partitioned.wrong;
+    };
+in
 {
   imports = [ wlib.modules.default ];
   options = {
     scripts = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];
+      internal = true;
+      apply =
+        x:
+        lib.warnIf (x != [ ])
+          "nix-wrapper-modules#mpv deprecation warning: `config.scripts` is deprecated, use `config.script.<name>.path = pkgs.mpvScripts.<name>` instead"
+          x;
       description = ''
-        A list of MPV user scripts to include via package override.
+        deprecated: use `config.script.<name>.path = pkgs.mpvScripts.<name>`
+      '';
+    };
+    script = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          { name, ... }:
+          {
+            options = {
+              enable = lib.mkEnableOption name // {
+                default = true;
+              };
+              opts = lib.mkOption {
+                type = lib.types.attrsOf (
+                  lib.types.nullOr (
+                    lib.types.oneOf [
+                      lib.types.number
+                      lib.types.bool
+                      wlib.types.stringable
+                    ]
+                  )
+                );
+                default = { };
+                description = ''
+                  Script options passed via `--script-opts-append`.
+                  Keys are prefixed with the sanitized script name.
+                '';
+              };
+              path = lib.mkOption {
+                type = lib.types.nullOr wlib.types.stringable;
+                default = null;
+                description = ''
+                  Path to an existing script file.
+                  Takes precedence over `content` if both are set.
 
-        Each entry should be a derivation providing a Lua script or plugin
-        compatible with MPV’s `scripts/` directory.
-        These are appended to MPV’s build with `pkgs.mpv.override`.
+                  If the value is a derivation with `passthru.scriptName` set,
+                  it will assume this is a package from `pkgs.mpvScripts` and handle it accordingly.
+                '';
+              };
+              content = lib.mkOption {
+                type = lib.types.nullOr lib.types.lines;
+                default = null;
+                description = ''
+                  Inline script file content.
+                  Used when `path` is null.
+                '';
+              };
+            };
+          }
+        )
+      );
+      default = { };
+      description = ''
+        MPV script files and their options.
+
+        Each key is the script name (used for sanitized option prefixes).
+        The `path` attribute specifies an existing script file (wins over content).
+        The `content` attribute specifies inline script content.
+        The `opts` attribute specifies script options passed via `--script-opts-append`.
+
+        Usage example:
+        ```nix
+        script = {
+          modernz = {
+            path = pkgs.mpvScripts.modernz;
+            opts = {
+              window_top_bar = false;
+            };
+          };
+          "visualizer.lua" = {
+            path = pkgs.mpvScripts.visualizer + "/share/mpv/scripts/visualizer.lua";
+            opts = {
+              mode = "force";
+            };
+          };
+          "my_script.lua".content = "print('hello world')";
+        };
+        ```
+        This generates: `--script-opts-append=modernz_window_top_bar=false`
+      '';
+      example = lib.literalMD ''
+        ```nix
+        script = {
+          modernz.path = pkgs.mpvScripts.modernz;
+          modernz.opts = {
+            window_top_bar = false;
+            seekbarfg_color = "#FFFFFF";
+          };
+        };
       '';
     };
     "mpv.input" = lib.mkOption {
@@ -43,29 +181,170 @@
         It is included by MPV using the `--include` flag.
       '';
     };
+    configDir = lib.mkOption {
+      type = lib.types.either wlib.types.stringable (
+        lib.types.attrsOf (
+          lib.types.submodule (
+            { name, ... }:
+            {
+              options = {
+                enable = lib.mkEnableOption name // {
+                  default = true;
+                };
+                path = lib.mkOption {
+                  type = lib.types.nullOr wlib.types.stringable;
+                  default = null;
+                  description = ''
+                    Path to an existing config file.
+                    Takes precedence over `content` if both are set.
+                  '';
+                };
+                content = lib.mkOption {
+                  type = lib.types.nullOr lib.types.lines;
+                  default = null;
+                  description = ''
+                    Inline config file content.
+                    Used when `path` is null.
+                  '';
+                };
+              };
+            }
+          )
+        )
+      );
+      default = { };
+      description = ''
+        Additional files to be included in the MPV config directory.
+
+        By using this option, mpv will no longer look for script-opts in the default
+        $XDG_CONFIG_HOME/mpv/script-opts location, and all additional files will have
+        to be specified in this option.
+
+        Each entry of the attrset is the relative path to the file and their content respectively.
+      '';
+      example = lib.literalMD ''
+        ```nix
+        {
+          "script-opts/modernz.conf".content = '''
+            window_top_bar=no
+            seekbarfg_color=#FFFFFF
+          ''';
+        };
+      '';
+      apply =
+        x:
+        lib.warnIf (x ? "mpv.input" || x ? "mpv.conf")
+          ''mpv.input is set via `config."mpv.input"`, not `config.configDir."mpv.input"`, and the same is true of `config."mpv.conf"` and `config.configDir."mpv.conf"`!''
+          x;
+    };
   };
+
   config.flagSeparator = "=";
   config.flags = {
-    "--input-conf" = config."mpv.input".path;
-    "--include" = config."mpv.conf".path;
-  };
-  config.constructFiles.generatedConfig = {
-    relPath = "${config.binName}-config/mpv.conf";
-    content = config."mpv.conf".content;
-  };
-  config.constructFiles.generatedInput = {
-    relPath = "${config.binName}-config/mpv.input";
-    content = config."mpv.input".content;
-  };
-  config.overrides = [
+    "--input-conf" = {
+      data = config."mpv.input".path;
+      sep = "=";
+    };
+    "--include" = lib.mkIf (config.configDir == { } || !builtins.isAttrs config.configDir) {
+      data = [ config."mpv.conf".path ];
+      sep = "=";
+    };
+    "--config-dir" = lib.mkIf (config.configDir != { }) (
+      if !builtins.isAttrs config.configDir then
+        config.configDir
+      else
+        dirOf config.constructFiles.generatedConfig.path
+    );
+  }
+  // (
+    let
+      scriptsData = lib.pipe partitioned.userScripts [
+        (lib.filterAttrs (n: v: v.path != null || v.content != null))
+        (lib.mapAttrsToList (n: _: config.constructFiles."scripts/${n}".path))
+      ];
+      scriptOptsData = lib.concatMap (
+        v:
+        let
+          sanitized = sanitizeScriptName v.name;
+        in
+        if v.value.opts == { } then
+          [ ]
+        else
+          builtins.concatLists (
+            lib.mapAttrsToList (
+              k: v:
+              if v == null then [ ] else [ "${sanitized}-${k}=${if lib.isStringLike v then v else toString v}" ]
+            ) v.value.opts
+          )
+      ) (lib.mapAttrsToList lib.nameValuePair config.script);
+    in
     {
-      name = "MPV_SCRIPTS";
-      type = "override";
-      data = prev: {
-        scripts = (prev.scripts or [ ]) ++ config.scripts;
+      "--scripts-append" =
+        lib.mkIf (scriptsData != [ ] && (config.configDir == { } || !builtins.isAttrs config.configDir))
+          {
+            sep = "=";
+            ifs = ":";
+            data = scriptsData;
+          };
+      "--script-opts-append" = lib.mkIf (scriptOptsData != [ ]) {
+        sep = "=";
+        ifs = ",";
+        data = scriptOptsData;
       };
     }
-  ];
+  );
+
+  config.constructFiles =
+    lib.pipe config.configDir [
+      (lib.filterAttrs (_: v: v.enable && (v.path != null || v.content != null)))
+      (builtins.mapAttrs (
+        name: v: {
+          content = if builtins.isString (v.content or null) then v.content else "";
+          output = lib.mkOverride 0 config.constructFiles.generatedConfig.output;
+          relPath = lib.mkOverride 0 "${dirOf config.constructFiles.generatedConfig.relPath}/${name}";
+          ${if v.path or null != null then "builder" else null} =
+            ''mkdir -p "$(dirname "$2")" && ln -s "${v.path}" "$2"'';
+        }
+      ))
+    ]
+    // lib.pipe partitioned.userScripts [
+      (lib.filterAttrs (_: v: v.path != null || v.content != null))
+      (lib.mapAttrs' (
+        name: v:
+        lib.nameValuePair "scripts/${name}" {
+          content = if builtins.isString (v.content or null) then v.content else "";
+          output = lib.mkOverride 0 config.constructFiles.generatedConfig.output;
+          relPath = lib.mkOverride 0 "${dirOf config.constructFiles.generatedConfig.relPath}/scripts/${name}";
+          ${if v.path or null != null then "builder" else null} =
+            ''mkdir -p "$(dirname "$2")" && ln -s "${v.path}" "$2"'';
+        }
+      ))
+    ]
+    // {
+      generatedConfig = {
+        relPath = "${config.binName}-config/mpv.conf";
+        content = config."mpv.conf".content;
+      };
+      generatedInput = {
+        relPath = lib.mkOverride 0 "${dirOf config.constructFiles.generatedConfig.relPath}/input.conf";
+        output = lib.mkOverride 0 config.constructFiles.generatedConfig.output;
+        content = config."mpv.input".content;
+      };
+    };
+
+  config.passthru.generatedConfig = dirOf config.constructFiles.generatedConfig.outPath;
+
+  config.overrides =
+    lib.mkIf (config.scripts or [ ] != [ ] || partitioned.nixpkgsScripts or [ ] != [ ])
+      [
+        {
+          name = "MPV_SCRIPTS";
+          type = "override";
+          data = prev: {
+            scripts = (prev.scripts or [ ]) ++ config.scripts ++ partitioned.nixpkgsScripts;
+          };
+        }
+      ];
   config.package = lib.mkDefault pkgs.mpv;
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }


### PR DESCRIPTION
see https://github.com/BirdeeHub/nix-wrapper-modules/pull/403

changes `config.scripts` list into a `config.script.<name>.{ path ? null, content ? null, opts ? { }, enable ? true }` option.

Detects if path is a nixpkgs one or not by checking for `passthru.scriptName`, if path is provided, path beats content

Adds `config.configDir.<name>.{ path ? null, content ? null, enable ? true }`

@iynaix, thoughts?

In particular, should we deprecate `config.scripts` and have the detection for if `.path` is a nixpkgs one, or leave both `config.script` and `config.scripts` as things and rename one of them? Maybe we could just rename `config.scripts` to `config.nixpkgsScripts` and remove the detection thing? But the detection thing is kinda nice also