### PR TITLE
fix(wrapperModules.zathura): default wrapper should support pdf

### DIFF
--- a/wrapperModules/z/zathura/module.nix
+++ b/wrapperModules/z/zathura/module.nix
@@ -81,6 +81,7 @@ in
         zathura_cb
         zathura_djvu
         zathura_ps
+        zathura_pdf_mupdf
       ];
       description = ''
         Add plugins to zathura runtime.


### PR DESCRIPTION
Building with the default options produces a binary without the pdf plugin, resulting in the following error `error: Could not determine file type.` and a blank window when trying to open any pdf.

The original wrapper from nixpkgs includes a pdf plugin: https://github.com/NixOS/nixpkgs/blob/eed82caeb00ab74f15d9b53b1cfa84e259d40f97/pkgs/applications/misc/zathura/wrapper.nix#L17