### PR TITLE
fix(lib.types.specWith): main field detection made lazier

### DIFF
--- a/lib/specWith.nix
+++ b/lib/specWith.nix
@@ -69,7 +69,7 @@ let
 
       baseNoCheck = base.extendModules { modules = [ noCheckForDocsModule ]; };
       withoutDefaults = attrNames (
-        filterAttrs (n: v: isOption v && !(v.isDefined or true)) baseNoCheck.options
+        filterAttrs (n: v: isOption v && v.highestPrio == 9999) baseNoCheck.options
       );
       main_field =
         if isString mainField then


### PR DESCRIPTION
https://github.com/BirdeeHub/nix-wrapper-modules/discussions/326#discussioncomment-16549327

allows using the main field's value for defaults in the other fields

in exchange for `lib.mkOption { default = mkIf false null; ... }` <- this counts as having a default field... So lazyAttrs rules for detecting the main field. `lib.mkOption { default = wlib.ignoreSpecField; ... }`

Theres no way to make a deprecation warning for this which is reasonable, I also am quite sure nobody was relying on `mkIf` there yet, and you can still use `optionalAttrs` to achieve the same effect.