### PR TITLE
feat(wrapperModules.tmux): improve plugins option

### DIFF
--- a/wrapperModules/t/tmux/module.nix
+++ b/wrapperModules/t/tmux/module.nix
@@ -21,31 +21,14 @@ let
 
   configPlugins =
     plugins:
-    (
-      let
-        pluginName = p: if lib.types.package.check p then p.pname else p.plugin.pname;
-        pluginRTP = p: if lib.types.package.check p then p.rtp else p.plugin.rtp;
-        pluginConfigPre = p: if lib.types.package.check p then "" else p.configBefore or "";
-        pluginConfigPost = p: if lib.types.package.check p then "" else p.configAfter or "";
-      in
-      if plugins == [ ] || !(builtins.isList plugins) then
-        ""
-      else
-        ''
-          # ============================================== #
-          ${
-            (lib.concatMapStringsSep "\n\n" (p: ''
-              # ${pluginName p}
-              # ---------------------
-              ${pluginConfigPre p}
-              run-shell ${pluginRTP p}
-              ${pluginConfigPost p}
-              # ---------------------
-            '') plugins)
-          }
-          # ============================================== #
-        ''
-    );
+    lib.concatMapStringsSep "\n\n" (p: ''
+      # ${toString p.name}
+      # ---------------------
+      ${p.configBefore}
+      run-shell ${p.rtp}
+      ${p.configAfter}
+      # ---------------------
+    '') (wlib.dag.unwrapSort "tmux plugins" plugins);
   tmux_bool_conv = v: if v then "on" else "off";
 in
 {
@@ -83,14 +66,50 @@ in
       default = [ ];
       description = "List of tmux plugins to source.";
       type = lib.types.listOf (
-        lib.types.oneOf [
-          lib.types.package
-          (lib.types.submodule {
+        wlib.types.spec (
+          { config, ... }:
+          {
             options = {
               plugin = lib.mkOption {
-                type = lib.types.package;
+                type = wlib.types.stringable;
                 description = ''
                   the tmux plugin to source
+                '';
+              };
+              rtp = lib.mkOption {
+                type = wlib.types.stringable;
+                default =
+                  config.plugin.rtp
+                    or "${config.plugin}${lib.optionalString (config.name != null) "/${config.name}.tmux"}";
+                description = ''
+                  The path actually sourced via `run-shell` within the plugin provided to the plugin field.
+
+                  If the plugin has an `rtp` attribute, as the plugins from `pkgs.tmuxPlugins` do, then that is used as the default.
+
+                  If it does not, "''${plugin}/''${plugin.pname}.tmux" is used.
+
+                  If it does not have a `pname` attribute either, then the provided path is used directly.
+                '';
+              };
+              name = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = config.plugin.pname or null;
+                description = ''
+                  Name of the plugin, can be targeted by the before and after fields of other plugin specs
+                '';
+              };
+              before = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                description = ''
+                  Plugins to source this plugin before
+                '';
+              };
+              after = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                description = ''
+                  Plugins to source this plugin after
                 '';
               };
               configBefore = lib.mkOption {
@@ -108,8 +127,8 @@ in
                 '';
               };
             };
-          })
-        ]
+          }
+        )
       );
     };
     prefix = lib.mkOption {
@@ -279,9 +298,15 @@ in
             bind-key -N "Kill the current pane" x kill-pane
           ''}
 
+          # ============================================== #
+
           ${config.configBefore}
 
+          # ============================================== #
+
           ${configPlugins config.plugins}
+
+          # ============================================== #
 
           ${config.configAfter}
         ''
@@ -290,7 +315,7 @@ in
     runShell = lib.mkIf config.secureSocket [
       ''export TMUX_TMPDIR=''${TMUX_TMPDIR:-''${XDG_RUNTIME_DIR:-"/run/user/$(id -u)"}}''
     ];
-    package = pkgs.tmux;
+    package = lib.mkDefault pkgs.tmux;
     meta.maintainers = [ wlib.maintainers.birdee ];
   };
 }


### PR DESCRIPTION
now uses a spec type rather than `lib.types.oneOf`. Main field still is `plugin`, to avoid breaking existing configurations. This also improves support for tmux plugins from sources outside of nixpkgs.

The reason it did not already use a spec type for this, is that this module was added before the spec type was created.