### PR TITLE
feat(wrapperModules.tmux): improve plugins option

### DIFF
--- a/ci/docs/per-mod/rendermd.nix
+++ b/ci/docs/per-mod/rendermd.nix
@@ -84,7 +84,13 @@ let
 
         ${mkOptField opt "description" ""}${mkOptField opt "relatedPackages" "Related packages:\n"}${
           mkOptField opt "type" "Type:${lib.optionalString (opt.readOnly or false == true) " (read-only)"}"
-        }${mkOptField opt "default" "Default:"}${mkOptField opt "example" "Example:"}${
+        }${
+          let
+            # default can depend on another field without a default value
+            res = builtins.tryEval (mkOptField opt "default" "Default:");
+          in
+          if res.success or false then res.value else ""
+        }${mkOptField opt "example" "Example:"}${
           lib.optionalString (opt.declarations or [ ] != [ ]) ''
             Declared by:
 

--- a/wrapperModules/t/tmux/module.nix
+++ b/wrapperModules/t/tmux/module.nix
@@ -21,31 +21,14 @@ let
 
   configPlugins =
     plugins:
-    (
-      let
-        pluginName = p: if lib.types.package.check p then p.pname else p.plugin.pname;
-        pluginRTP = p: if lib.types.package.check p then p.rtp else p.plugin.rtp;
-        pluginConfigPre = p: if lib.types.package.check p then "" else p.configBefore or "";
-        pluginConfigPost = p: if lib.types.package.check p then "" else p.configAfter or "";
-      in
-      if plugins == [ ] || !(builtins.isList plugins) then
-        ""
-      else
-        ''
-          # ============================================== #
-          ${
-            (lib.concatMapStringsSep "\n\n" (p: ''
-              # ${pluginName p}
-              # ---------------------
-              ${pluginConfigPre p}
-              run-shell ${pluginRTP p}
-              ${pluginConfigPost p}
-              # ---------------------
-            '') plugins)
-          }
-          # ============================================== #
-        ''
-    );
+    lib.concatMapStringsSep "\n\n" (p: ''
+      # ${toString p.name}
+      # ---------------------
+      ${p.configBefore}
+      run-shell ${p.rtp}
+      ${p.configAfter}
+      # ---------------------
+    '') (wlib.dag.unwrapSort "tmux plugins" plugins);
   tmux_bool_conv = v: if v then "on" else "off";
 in
 {
@@ -83,14 +66,56 @@ in
       default = [ ];
       description = "List of tmux plugins to source.";
       type = lib.types.listOf (
-        lib.types.oneOf [
-          lib.types.package
-          (lib.types.submodule {
+        wlib.types.spec (
+          { config, ... }:
+          {
+            # NOTE: set here because if you put them in the actual default field,
+            # nixpkgs doc generator will try to show them.
+            # Ours actually won't, for our doc generator putting them in the normal place would be fine.
+            config.name = lib.mkOptionDefault (config.plugin.pname or null);
+            config.rtp = lib.mkOptionDefault (
+              config.plugin.rtp
+                or "${config.plugin}${lib.optionalString (config.name != null) "/${config.name}.tmux"}"
+            );
             options = {
               plugin = lib.mkOption {
-                type = lib.types.package;
+                type = wlib.types.stringable;
                 description = ''
                   the tmux plugin to source
+
+                  Used to determine `plugins.*.rtp` field
+                '';
+              };
+              rtp = lib.mkOption {
+                type = wlib.types.stringable;
+                description = ''
+                  The path actually sourced via `run-shell` within the plugin provided to the plugin field.
+
+                  If the plugin has an `rtp` attribute, as the plugins from `pkgs.tmuxPlugins` do, then that is used as the default.
+
+                  If it does not, `"''${plugin}/''${plugin.pname}.tmux"` is used.
+
+                  If it does not have a `pname` attribute either, then the provided path is used directly.
+                '';
+              };
+              name = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                description = ''
+                  Name of the plugin, can be targeted by the before and after fields of other plugin specs
+                '';
+              };
+              before = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                description = ''
+                  Plugins to source this plugin before
+                '';
+              };
+              after = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                description = ''
+                  Plugins to source this plugin after
                 '';
               };
               configBefore = lib.mkOption {
@@ -108,8 +133,8 @@ in
                 '';
               };
             };
-          })
-        ]
+          }
+        )
       );
     };
     prefix = lib.mkOption {
@@ -279,9 +304,15 @@ in
             bind-key -N "Kill the current pane" x kill-pane
           ''}
 
+          # ============================================== #
+
           ${config.configBefore}
 
+          # ============================================== #
+
           ${configPlugins config.plugins}
+
+          # ============================================== #
 
           ${config.configAfter}
         ''
@@ -290,7 +321,7 @@ in
     runShell = lib.mkIf config.secureSocket [
       ''export TMUX_TMPDIR=''${TMUX_TMPDIR:-''${XDG_RUNTIME_DIR:-"/run/user/$(id -u)"}}''
     ];
-    package = pkgs.tmux;
+    package = lib.mkDefault pkgs.tmux;
     meta.maintainers = [ wlib.maintainers.birdee ];
   };
 }


### PR DESCRIPTION
now uses a `wlib.types.spec` type rather than `lib.types.oneOf`. Main field still is `plugin`, to avoid breaking existing configurations. This also improves support for tmux plugins from sources outside of nixpkgs.

The reason it did not already use a spec type for this, is that this module was added before the spec type was created.