### PR TITLE
fix(wrapperModules.yazi): provide some way of installing plugins

### DIFF
--- a/wrapperModules/y/yazi/module.nix
+++ b/wrapperModules/y/yazi/module.nix
@@ -447,6 +447,49 @@ in
     '';
   };
 
+  options.plugins = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.nullOr wlib.types.stringable);
+    default = { };
+    description = ''
+      An attribute set of plugin names and their paths
+    '';
+    example = lib.literalMD ''
+      ```nix
+      with pkgs.yaziPlugins; {
+        smart-enter = smart-enter;
+        drag = inputs.drag;
+        gvfs = inputs.gvfs-yazi;
+        git = git;
+        starship = starship;
+        full-border = full-border;
+      };
+      ```
+    '';
+  };
+  options.flavors = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.nullOr wlib.types.stringable);
+    default = { };
+    description = ''
+      An attribute set of flavor names and their paths
+    '';
+  };
+  config.buildCommand.makePluginsAndFlavors = {
+    before = [ "constructFiles" ]; # <- by default constructFiles is the first of the 3 in modules.default
+    data =
+      let
+        toLink =
+          dir: n: v:
+          lib.optionalString (v != null)
+            "ln -s ${lib.escapeShellArg v} ${lib.escapeShellArg "${config.generatedConfig.placeholder}/${dir}/${n}.yazi"}";
+      in
+      ''
+        mkdir -p ${lib.escapeShellArg "${config.generatedConfig.placeholder}/plugins"}
+        mkdir -p ${lib.escapeShellArg "${config.generatedConfig.placeholder}/flavors"}
+      ''
+      + lib.concatMapAttrsStringSep "\n" (toLink "plugins") config.plugins
+      + lib.concatMapAttrsStringSep "\n" (toLink "flavors") config.flavors;
+  };
+
   config.package = lib.mkDefault pkgs.yazi;
   config.env.YAZI_CONFIG_HOME = config.generatedConfig.placeholder;
   # make `finalpackage.generatedConfig` point to the generated config so it can be used from outside of the wrapper module


### PR DESCRIPTION
https://github.com/BirdeeHub/nix-wrapper-modules/issues/395 ?

This is greatly improved from its previous state of having no way to install plugins other than doing this yourself.

Im not super happy about this. I am finding out they didn't bother to do an RTP, and they didn't allow you to change the dir that ya uses. If they used an RTP for plugins rather than just a single path, and then let us set where the ya download and lockfile locations are, it would be fantastic but that is not available. I looked really hard but there is nothing like that.

So, unless we do what we did for noctalia-shell, where we also provide options for copying it out of the store at runtime, we can only provide plugins via nix now.

That being said, theres no build steps or anything and nix is good at fetching stuff, and there are already yazi plugins in nixpkgs, so it isn't that big of a deal. So I am thinking for now this might be fine, and maybe those other options could be added someday if necessary.

It also is much better than not having any way to provide them at all without doing this yourself, which is the current situation.

We really need services options and/or bubblewrap for solving these "requires writable config for some features" problems better.