### PR TITLE
fix(wlib.types.file): made it slightly less cumbersome to use properly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,13 +45,15 @@ You may optionally set the `meta.description` option to provide a short descript
 
 `pre` will be added after the title and before the content. `post` will be added after the content.
 
+Do not name an option `options` or `config` if there is a chance the module system will try to use them as if they were top level module declarations.
+
 ## Guidelines and Examples:
 
 When you provide an option to `enable` or `disable` something, you should call it `enable` regardless of its default value.
 
 This prevents people from needing to look it up to use it, and prevents contributors from having to think too hard about which to call it.
 
-- Placeholders
+- Placeholders and `config.constructFiles.<name>`
 
 When you generate a file, it is generally better to do so as a string, and create it using the `constructFiles` option.
 
@@ -66,17 +68,11 @@ It works by using `drv.passAsFile` and making a derivation attribute with the fi
 
 - `wlib.types.file`
 
-When you provide a `wlib.types.file` option, you should name it the actual filename, especially if there are multiple, but `configFile` is also OK, especially if it is unambiguous.
+When you provide a `wlib.types.file` option, you should name it the actual filename or something suggestive of it, especially if there are multiple, but `configFile` is also OK, especially if it is unambiguous.
 
 Keep in mind that even if you do not choose to use `wlib.types.file`, the user can usually still override the option that you set to provide the generated path if needed.
 
 So using something like `wlib.types.file` is only truly important when the file you are making an option for is passed to a list-style option, but may still be nice more generally.
-
-However:
-
-For the same reason that we use `constructFiles` to build files, using `wlib.types.file` without overriding its default `path` value is discouraged in modules to be submitted to this repository.
-
-It builds the file using `pkgs.writeText` by default, and because this creates an intermediate derivation, it means placeholders in that file will not point to the final wrapper derivation.
 
 Example:
 
@@ -100,13 +96,11 @@ Example:
       '';
     };
     configFile = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default = {
-        content = "";
-        # we should override the default path value for wlib.types.file if we can to make placeholders work
-        # to do that, we can refer to the placeholder of our constructed file!
-        path = config.constructFiles.gitconfig.path;
+      type = wlib.types.file {
+        # we can refer to the placeholder of our constructed file!
+        path = lib.mkOptionDefault config.constructFiles.gitconfig.path;
       };
+      default = { };
       description = "Generated git configuration file.";
     };
   };

--- a/ci/checks/types-file.nix
+++ b/ci/checks/types-file.nix
@@ -54,7 +54,7 @@ let
   evaledModuleWithOptionDefault = lib.evalModules {
     modules = [
       module
-      { fileWithContent.content = lib.mkOptionDefault "test content5"; }
+      { fileWithContent.content = lib.mkDefault "test content5"; }
       # those two cause `content was accessed but no value defined` errors
       # { fileWithPathOverride.path = lib.mkOptionDefault "/etc/hosts5"; }
       # {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -422,41 +422,90 @@ in
   );
 
   /**
-    File type with content and path options
+    A simple template option for when you wish to offer options concerning generating a text file
+
+    ```nix
+    options.configFile = lib.mkOption {
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.gitconfig.path;
+      };
+      default = { };
+      description = "Generated git configuration file.";
+    };
+    config.constructFiles.gitconfig = {
+      relPath = "${config.binName}config";
+      content = lib.generators.toGitINI config.settings + "\n" + config.configFile.content;
+    };
+    ```
+
+    If instead of a module, you pass it nixpkgs, it will set defaults for `configFile.path` to `pkgs.writeText name content`
 
     Arguments:
-    - `pkgs`: nixpkgs instance
+    - `extra`: extra module(s) for the submodule option. Can instead be `pkgs` for a shorthanding effect.
 
     Fields:
-    - `content`: File contents as string
-    - `path`: Derived path using `pkgs.writeText`
+    - `content`: File contents as string, defaults to `""`
+    - `path`: Normally no default, you should provide one. But if the type is provided `pkgs` instead of modules, it contains a derived path using `pkgs.writeText`
   */
   file =
-    # we need to pass pkgs here, because writeText is in pkgs
-    pkgs:
-    lib.types.submodule (
-      { name, config, ... }:
-      {
-        options = {
-          content = lib.mkOption {
-            type = lib.types.lines;
-            description = ''
-              Content of the file. This can be a multi-line string that will be
-              written to the Nix store and made available via the path option.
-            '';
-          };
-          path = lib.mkOption {
-            type = wlib.types.stringable;
-            description = ''
-              The path to the file. By default, this is automatically
-              generated using pkgs.writeText with the attribute name and content.
-            '';
-            default = pkgs.writeText name config.content;
-            defaultText = lib.literalExpression "pkgs.writeText name <content>";
-          };
-        };
-      }
-    );
+    arg:
+    let
+      withDefaultPath =
+        pkgs:
+        lib.types.submodule (
+          {
+            name,
+            config,
+            _prefix,
+            ...
+          }:
+          {
+            options = {
+              content = lib.mkOption {
+                type = lib.types.lines;
+                default = "";
+                description = ''
+                  Content of the file specified by `${lib.options.showOption _prefix}`.
+                  This is a multi-line string that will be written to the Nix store.
+                '';
+              };
+              path = lib.mkOption {
+                type = wlib.types.stringable;
+                description = ''
+                  The path to the file specified by `${lib.options.showOption _prefix}`
+                '';
+                default = pkgs.writeText name config.content;
+                defaultText = lib.literalMD "```nix\npkgs.writeText ${name} <content>\n```";
+              };
+            };
+          }
+        );
+      textFile =
+        extra:
+        lib.types.submodule (
+          { _prefix, ... }:
+          {
+            imports = lib.toList extra;
+            options = {
+              content = lib.mkOption {
+                type = lib.types.lines;
+                default = "";
+                description = ''
+                  Content of the file specified by `${lib.options.showOption _prefix}`.
+                  This is a multi-line string that will be written to the Nix store.
+                '';
+              };
+              path = lib.mkOption {
+                type = wlib.types.stringable;
+                description = ''
+                  The path to the file specified by `${lib.options.showOption _prefix}`
+                '';
+              };
+            };
+          }
+        );
+    in
+    if lib.types.pkgs.check arg then withDefaultPath arg else textFile arg;
 
   /**
     Like `lib.types.anything`, but allows contained lists to also be merged

--- a/wrapperModules/f/fastfetch/module.nix
+++ b/wrapperModules/f/fastfetch/module.nix
@@ -9,7 +9,7 @@
   imports = [ wlib.modules.default ];
   options = {
     settings = lib.mkOption {
-      type = lib.types.json;
+      type = lib.types.json or (pkgs.formats.json { }).type;
       default = { };
       description = ''
         Configuration passed to fastfetch using `--config` flag

--- a/wrapperModules/g/git/module.nix
+++ b/wrapperModules/g/git/module.nix
@@ -17,9 +17,10 @@
       '';
     };
     configFile = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.path = config.constructFiles.gitconfig.path;
-      default.content = "";
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.gitconfig.path;
+      };
+      default = { };
       description = "Generated git configuration file.";
     };
   };

--- a/wrapperModules/m/mako/module.nix
+++ b/wrapperModules/m/mako/module.nix
@@ -13,9 +13,10 @@ in
   imports = [ wlib.modules.default ];
   options = {
     "--config" = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.path = config.constructFiles.generatedConfig.path;
-      default.content = "";
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+      };
+      default = { };
       description = ''
         Path to the generated Mako configuration file.
 

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -25,14 +25,15 @@
     };
 
     configFile = lib.mkOption {
-      type = wlib.types.file pkgs;
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+      };
+      default = { };
       description = ''
         Config file that mango will set as its config file.
 
         Note: If configFile.path or configFile.content is set, it will overwrite the effects of the `sourcedFiles` and `extraContent` options.
       '';
-      default.path = config.constructFiles.generatedConfig.path;
-      default.content = "";
       example = ''
         {
           path = ./config.conf;

--- a/wrapperModules/m/mdbook/module.nix
+++ b/wrapperModules/m/mdbook/module.nix
@@ -189,7 +189,7 @@ let
       linkCmds = builtins.concatStringsSep "\n" (map mkLink sortedBook);
     };
 
-  tomltype = lib.types.json // {
+  tomltype = (lib.types.json or (pkgs.formats.json { }).type) // {
     description = "nullable TOML value";
   };
 

--- a/wrapperModules/m/mpv/module.nix
+++ b/wrapperModules/m/mpv/module.nix
@@ -145,9 +145,10 @@ in
       '';
     };
     "mpv.input" = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.path = config.constructFiles.generatedInput.path;
-      default.content = "";
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedInput.path;
+      };
+      default = { };
       description = ''
         The MPV input configuration file.
 
@@ -157,9 +158,10 @@ in
       '';
     };
     "mpv.conf" = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.path = config.constructFiles.generatedConfig.path;
-      default.content = "";
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+      };
+      default = { };
       description = ''
         The main MPV configuration file.
 

--- a/wrapperModules/n/niri/module.nix
+++ b/wrapperModules/n/niri/module.nix
@@ -288,9 +288,10 @@ in
       };
     };
     "config.kdl" = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.path = config.constructFiles.generatedConfig.path;
-      default.content = "";
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+      };
+      default = { };
       description = ''
         Configuration file for Niri.
         See <https://github.com/YaLTeR/niri/wiki/Configuration:-Introduction>

--- a/wrapperModules/n/noctalia-shell/module.nix
+++ b/wrapperModules/n/noctalia-shell/module.nix
@@ -101,7 +101,7 @@ in
       '';
     };
     settings = lib.mkOption {
-      type = lib.types.json;
+      type = lib.types.json or (pkgs.formats.json { }).type;
       default = { };
       example = lib.literalExpression ''
         {
@@ -127,7 +127,7 @@ in
     };
 
     colors = lib.mkOption {
-      type = lib.types.json;
+      type = lib.types.json or (pkgs.formats.json { }).type;
       default = { };
       example = lib.literalExpression ''
          {
@@ -175,7 +175,7 @@ in
     };
 
     plugins = lib.mkOption {
-      type = lib.types.json;
+      type = lib.types.json or (pkgs.formats.json { }).type;
       default = { };
       example = lib.literalExpression ''
         {
@@ -202,7 +202,7 @@ in
     };
 
     pluginSettings = lib.mkOption {
-      type = with lib.types; attrsOf json;
+      type = lib.types.attrsOf (lib.types.json or (pkgs.formats.json { }).type);
       default = { };
       example = lib.literalExpression ''
         {
@@ -275,7 +275,7 @@ in
               '';
             };
             settings = lib.mkOption {
-              type = lib.types.json;
+              type = lib.types.json or (pkgs.formats.json { }).type;
               default = { };
               description = ''
                 Settings to add to `$NOCTALIA_CONFIG_DIR/plugins/plugin-name/settings.json`

--- a/wrapperModules/n/notmuch/module.nix
+++ b/wrapperModules/n/notmuch/module.nix
@@ -34,9 +34,10 @@ in
       '';
     };
     configFile = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.path = config.constructFiles.generatedConfig.path;
-      default.content = "";
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+      };
+      default = { };
       description = ''
         Path or inline definition of the generated Notmuch configuration file.
 

--- a/wrapperModules/n/nushell/module.nix
+++ b/wrapperModules/n/nushell/module.nix
@@ -9,9 +9,10 @@
   imports = [ wlib.modules.default ];
   options = {
     "env.nu" = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.content = "";
-      default.path = config.constructFiles.generatedEnv.path;
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedEnv.path;
+      };
+      default = { };
       description = ''
         The Nushell environment configuration file.
 
@@ -21,9 +22,10 @@
       '';
     };
     "config.nu" = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.content = "";
-      default.path = config.constructFiles.generatedConfig.path;
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+      };
+      default = { };
       description = ''
         The main Nushell configuration file.
 

--- a/wrapperModules/r/rofi/module.nix
+++ b/wrapperModules/r/rofi/module.nix
@@ -103,16 +103,18 @@ in
   imports = [ wlib.modules.default ];
   options = {
     "config.rasi" = lib.mkOption {
-      type = wlib.types.file pkgs;
-      default.path = config.constructFiles.generatedConfig.path;
-      default.content =
-        toRasi {
-          configuration = config.settings;
-        }
-        + (lib.optionalString (config.theme != null) (toRasi {
-          "@theme" =
-            if builtins.isAttrs config.theme then config.constructFiles.generatedTheme.path else config.theme;
-        }));
+      type = wlib.types.file {
+        path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+        content =
+          toRasi {
+            configuration = config.settings;
+          }
+          + (lib.optionalString (config.theme != null) (toRasi {
+            "@theme" =
+              if builtins.isAttrs config.theme then config.constructFiles.generatedTheme.path else config.theme;
+          }));
+      };
+      default = { };
       description = ''
         The main Rofi configuration file (`config.rasi`).
 

--- a/wrapperModules/w/wezterm/module.nix
+++ b/wrapperModules/w/wezterm/module.nix
@@ -26,9 +26,11 @@
     '';
   };
   options."wezterm.lua" = lib.mkOption {
-    type = wlib.types.file pkgs;
-    default.content = "return require('nix-info')";
-    default.path = config.constructFiles."wezterm.lua".path;
+    type = wlib.types.file {
+      path = lib.mkOptionDefault config.constructFiles."wezterm.lua".path;
+      content = lib.mkOptionDefault "return require('nix-info')";
+    };
+    default = { };
     description = "The wezterm config file. provide `.content`, or `.path`";
   };
   options.luaInfo = lib.mkOption {


### PR DESCRIPTION
`wlib.types.file` now can accept modules instead of `pkgs` as its argument.

Related:

https://github.com/BirdeeHub/nix-wrapper-modules/issues/447

Also fixed https://github.com/BirdeeHub/nix-wrapper-modules/issues/449 by making existing modules fall back to `(pkgs.formats.json { }).type` if `lib.types.json` is not present