### PR TITLE
WIP feat(tests): add test utils v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,11 +155,7 @@ Sometimes it is not easily possible to run the program within a derivation, in t
 Example:
 
 ```nix
-{
-  pkgs,
-  runCommand,
-  self,
-}:
+{ pkgs, self, tlib, ... }:
 let
   gitWrapped = self.wrappers.git.wrap {
     inherit pkgs;
@@ -170,12 +166,18 @@ let
       };
     };
   };
+  inherit (tlib) it fileContains test enableBySystem ;
 in
-runCommand "git-test" { } ''
-  "${gitWrapped}/bin/git" config user.name | grep -q "Test User"
-  "${gitWrapped}/bin/git" config user.email | grep -q "test@example.com"
-  touch $out
-''
+# git uses meta.platforms = lib.platforms.all, so this will be enabled on all platforms
+enableBySystem self.wrappers.git (
+  # define a test derivation using the testing library!
+  test "git-test" [
+    # define tests for your test derivation using `it` and the other helpers
+    (it "has test user" ''"${gitWrapped}/bin/git" config user.name | grep -q "Test User"'')
+    (it "has test email" ''"${gitWrapped}/bin/git" config user.email | grep -q "test@example.com"'')
+    (fileContains (gitWrapped.configuration.constructFiles.gitconfig.outPath) "test@example\.com")
+  ]
+)
 ```
 
 If your module declares a list of valid platforms via its `meta.platforms` option, you should disable your test on the relevant platforms like so:

--- a/ci/flake.nix
+++ b/ci/flake.nix
@@ -20,6 +20,7 @@
             inherit system;
             config.allowUnfree = true;
           };
+          tlib = pkgs.callPackage ./test-lib.nix { inherit self; };
 
           # Load checks from ci/checks/ directory
           coreAndCiChecks = lib.pipe ./checks [
@@ -43,7 +44,7 @@
                     name = "${prefix}-${name}";
                     inherit value;
                   };
-                  result = pkgs.callPackage value { inherit self; };
+                  result = pkgs.callPackage value { inherit self tlib; };
                 in
                 if result == null then
                   [ ]

--- a/ci/test-lib.nix
+++ b/ci/test-lib.nix
@@ -1,0 +1,193 @@
+{
+  self,
+  lib,
+  runCommand,
+  pkgs,
+  ...
+}:
+let
+  wlib = self.lib;
+  inherit (lib) isList;
+  toSanitizedJSON =
+    value:
+    if builtins.isAttrs value then
+      builtins.toJSON (
+        lib.mapAttrsRecursive (
+          path: v:
+          if builtins.isFunction v then
+            let
+              res = builtins.unsafeGetAttrPos (lib.last path) (
+                lib.getAttrFromPath (lib.sublist 0 (builtins.length path - 1) path) value
+              );
+            in
+            "<lambda${
+              if builtins.isAttrs res then
+                ":${res.file or ""}:${toString (res.line or "")}:${toString (res.column or "")}"
+              else
+                ""
+            }>"
+          else
+            v
+        ) value
+      )
+    else
+      builtins.toJSON value;
+
+  recursiveUpdateWithMerging = wlib.recursiveMergeUntil {
+    until =
+      path: lh: rh:
+      !(wlib.isNonDrvAttrs lh) || !(wlib.isNonDrvAttrs rh);
+    merge =
+      path: left: right:
+      if isList left && isList right then left ++ right else right;
+  };
+
+  enableForSystem =
+    system: value: test:
+    let
+      platforms =
+        if builtins.isList value then
+          value
+        else
+          value.passthru.configuration.meta.platforms or value.config.meta.platforms or value.meta.platforms
+            or (wlib.evalModule value).config.meta.platforms;
+    in
+    if builtins.elem system platforms then test else null;
+
+  test = message: condition: { inherit message condition; };
+in
+{
+  inherit enableForSystem toSanitizedJSON test;
+  enableBySystem = enableForSystem pkgs.stdenv.hostPlatform.system;
+
+  isDirectory = path: test "No such directory ${path}" ''[ -d "${path}" ]'';
+
+  isFile = path: test "No such file ${path}" ''[ -f "${path}" ]'';
+
+  notIsFile = path: test "File ${path} should not exist" ''[ ! -f "${path}" ]'';
+
+  fileContains =
+    file: pattern: test "Pattern '${pattern}' not found in ${file}" ''grep -q '${pattern}' "${file}"'';
+
+  areEqual =
+    expected: actual:
+    test (
+      if expected == actual then
+        "areEqual"
+      else
+        lib.escapeShellArg "Expected:\n${toSanitizedJSON expected}\nbut got:\n${toSanitizedJSON actual}"
+    ) (if expected == actual then "true" else "false");
+
+  /**
+    first argument is a string.
+    It is the name of the test derivation,
+    and default warning message name.
+
+    Second argument is of type `cond` as specified below
+
+    ```nix
+    cond = let
+      assertion = { condition :: cond, message :: str };
+    in str | assertion | [ (str | assertion) ] | (attrsOf cond);
+    ```
+
+    TODO: show usage
+
+    you can call .extend on the result to add more items
+    It is the same, but without the first name argument
+  */
+  mkTestDrv =
+    name:
+    let
+      idnt = len: "\n" + wlib.repeatStr "  " len;
+      createAssertion =
+        prefix:
+        { condition, message }:
+        let
+          loc = prefix ++ [ message ];
+          lvl = builtins.length loc;
+          renderCond =
+            first: c:
+            if lib.isStringLike c then
+              c
+            else if builtins.isList c then
+              let
+                conds = builtins.filter (v: v.cond or "" != [ ] && v.cond or v != "") c;
+              in
+              if conds == [ ] then
+                ""
+              else
+                "( " + lib.concatMapStringsSep " ) && ( " (renderCond false) conds + " )"
+            else if !first && builtins.isAttrs c then
+              createAssertion loc c
+            else if first && builtins.isAttrs c then
+              helper loc c
+            else
+              throw "Invalid condition type in assertion, received ${toSanitizedJSON c}";
+        in
+        if condition == [ ] then
+          ""
+        else
+          "(${idnt (lvl + 1)}${renderCond true condition}${idnt lvl}) || (echo 'failing test at:' ${lib.escapeShellArg "${lib.options.showOption prefix}:"} ${message} >&2; return 1)";
+      helper =
+        prefix: assertions:
+        let
+          lvl = builtins.length prefix;
+        in
+        if
+          builtins.isAttrs assertions
+          && (
+            lib.removeAttrs assertions [
+              "condition"
+              "message"
+            ] != { }
+          )
+        then
+          lib.concatMapAttrsStringSep "${idnt lvl}" (
+            n: v:
+            if v == [ ] then
+              ""
+            else
+              let
+                loc = prefix ++ [ n ];
+                text = helper loc v;
+              in
+              "(${idnt (lvl + 1)}${text}${idnt lvl}) || (echo 'failing test at:' ${lib.escapeShellArg "${lib.options.showOption prefix}:"} ${n} >&2 && ${
+                if builtins.length loc == 1 then "exit" else "return"
+              } 1)"
+          ) assertions
+        else
+          "(${idnt (lvl + 1)}"
+          + lib.concatMapStringsSep "${idnt lvl}) && (${idnt (lvl + 1)}" (
+            a: if lib.isStringLike a then "${a}" else createAssertion prefix a
+          ) (lib.toList assertions)
+          + "${idnt lvl})";
+      normArgs =
+        args:
+        if builtins.isList args then
+          { ${name} = args; }
+        else if lib.isStringLike args then
+          { ${name} = [ args ]; }
+        else
+          args;
+    in
+    wlib.makeCustomizable "extend"
+      {
+        mergeArgs =
+          og: new:
+          if lib.isFunction new then
+            new (normArgs og)
+          else
+            recursiveUpdateWithMerging (normArgs og) (normArgs new);
+      }
+      (
+        assertions:
+        let
+          finalText = helper [ ] (normArgs assertions);
+        in
+        runCommand name { passthru.test = finalText; } ''
+          ${finalText}
+          mkdir -p $out
+        ''
+      );
+}

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -607,6 +607,103 @@ in
       (builtins.attrNames attrs);
 
   /**
+    checks for an attribute set that is not string-like and returns true if it is
+  */
+  isNonDrvAttrs = v: builtins.isAttrs v && !lib.isStringLike v;
+
+  /**
+    A generalized recursive attribute set merge with user-defined stopping and
+    conflict resolution behavior.
+
+    This function is similar to `lib.recursiveUpdateUntil`, but extends it by
+    allowing a custom `merge` function to decide how values are merged when
+    recursion stops.
+
+    The merge walks both attribute sets (`lhs` and `rhs`) in parallel:
+
+    - If only one side defines a value at a given path, that value is used.
+    - If both sides define a value:
+      - `until path lhs rhs` is evaluated.
+        - If it returns `true`, recursion stops at this path and
+          `merge path lhs rhs` determines the result.
+        - If it returns `false`, recursion continues into the values (which are
+          expected to be attribute sets).
+
+    Default behavior:
+    - Recursion continues only while both values are attribute sets
+      (`builtins.isAttrs`).
+    - When recursion stops, the right-hand side (`rhs`) replaces the left-hand side.
+
+    Parameters:
+      - `until` :: `[string]` -> `any` -> `any` -> `bool`:
+        - Predicate that determines when to stop descending into values.
+        - Arguments:
+          - `path`: attribute path from the root (e.g. `[ "a" "b" "c" ]`)
+          - `lhs`: value from the left-hand side
+          - `rhs`: value from the right-hand side
+
+      - `merge` :: `[string]` -> `any` -> `any` -> `bool`:
+        - Function used to resolve a conflict when `until` returns true.
+          Receives the same arguments as `until`.
+
+    Arguments:
+      - `lhs` :: `attrset`:
+        Base attribute set.
+
+      - `rhs` :: `attrset`:
+        Overlay attribute set (takes precedence by default).
+
+    Returns:
+      - `attrset`:
+        The recursively merged result.
+
+    Notes:
+    - Merge is right-biased unless `merge` overrides that behavior.
+    - Non-attribute values are treated as leaves and resolved via `merge`.
+    - The `path` argument allows context-aware merging strategies.
+
+    Example (concatenate lists instead of replacing them):
+    ```nix
+      recursiveMergeUntil {
+        merge = path: l: r:
+          if builtins.isList l && builtins.isList r then l ++ r else r;
+      } { a = [1]; } { a = [2]; }
+
+      => { a = [1 2]; }
+    ```
+  */
+  recursiveMergeUntil =
+    # source: https://github.com/BirdeeHub/nixCats-nvim/blob/da76c45b33d589836946bb566bd91df4cd3cfb09/utils/lib.nix#L57
+    {
+      until ? (
+        path: lh: rh:
+        !(builtins.isAttrs lh) || !(builtins.isAttrs rh)
+      ),
+      merge ? (
+        path: l: r:
+        r
+      ),
+    }:
+    lhs: rhs:
+    let
+      f =
+        attrPath:
+        builtins.zipAttrsWith (
+          n: values:
+          let
+            here = attrPath ++ [ n ];
+          in
+          if builtins.length values == 1 then
+            builtins.head values
+          else if until here (builtins.elemAt values 1) (builtins.head values) then
+            merge here (builtins.elemAt values 1) (builtins.head values)
+          else
+            f here values
+        );
+    in
+    f [ ] [ rhs lhs ];
+
+  /**
     `genStr` :: `string` -> `int` -> `string`
 
     or

--- a/wrapperModules/d/direnv/check.nix
+++ b/wrapperModules/d/direnv/check.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  callPackage,
+  tlib,
+  self,
+  ...
+}@args:
+let
+  inherit (tlib) test enableBySystem areEqual;
+in
+builtins.mapAttrs (_: v: enableBySystem self.wrappers.direnv v) (
+  lib.fix (self: {
+    "1" = callPackage ./check1.nix args;
+    "2" = callPackage ./check2.nix args;
+    "3" = callPackage ./check3.nix args;
+    "4" = self."1".extend {
+      moretests = {
+        "another test" = "echo hello";
+        "another test2" = "echo world";
+      };
+      outer = {
+        inner = test "should have echoed 'hi'" "echo hi";
+        inner2 = test "should have echoed 'hi again'" { something = "echo 'hi again'"; };
+        inner3 = test "should have echoed 'woot'" (test "should have echoed 'woot'" "echo 'woot woot'");
+      };
+      zzz = [
+        (test "another test" {
+          like.this.too = "echo wtf1";
+        })
+      ];
+    };
+    "5" = self."4".extend [
+      (test "well... so... it" {
+        can.be.nested.like.this.too = [
+          (areEqual 2 2)
+          (areEqual
+            {
+              a = 1;
+              b = 2;
+              c = 3;
+              inherit enableBySystem;
+            }
+            {
+              a = 1;
+              b = 2;
+              c = 3;
+              inherit enableBySystem;
+            }
+          )
+        ];
+      })
+      (test "is" {
+        a.bit.strange = "echo 'but it completed the loop nicely'";
+      })
+    ];
+  })
+)

--- a/wrapperModules/d/direnv/check1.nix
+++ b/wrapperModules/d/direnv/check1.nix
@@ -1,0 +1,157 @@
+{
+  pkgs,
+  self,
+  tlib,
+  ...
+}:
+
+let
+  inherit (tlib)
+    fileContains
+    isDirectory
+    isFile
+    notIsFile
+    ;
+  getDotdir = wrapper: "${wrapper}/${wrapper.configuration.configDirname}";
+in
+tlib.mkTestDrv "direnv-tests" [
+  {
+    message = "wrapper should output correct version";
+    condition =
+      let
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+        };
+      in
+      ''
+        "${wrapper}/bin/direnv" --version | grep -q "${wrapper.version}"
+      '';
+  }
+  {
+    message = "if nix-direnv is enabled then lib/nix-direnv.sh should exists";
+    condition =
+      let
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+          nix-direnv.enable = true;
+        };
+      in
+      [
+        (isDirectory (getDotdir wrapper))
+        (isFile "${getDotdir wrapper}/lib/nix-direnv.sh")
+      ];
+  }
+  {
+    message = "if nix-direnv is disabled then lib/nix-direnv.sh should not exist";
+    condition =
+      let
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+          nix-direnv.enable = false;
+        };
+      in
+      [
+        (isDirectory (getDotdir wrapper))
+        (notIsFile "${getDotdir wrapper}/lib/nix-direnv.sh")
+      ];
+  }
+  {
+    message = "if mise is enabled then lib/mise.sh should exists";
+    condition =
+      let
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+          mise.enable = true;
+        };
+      in
+      [
+        (isDirectory (getDotdir wrapper))
+        (isFile "${getDotdir wrapper}/lib/mise.sh")
+      ];
+  }
+  {
+    message = "if mise is disabled then lib/mise.sh should not exist";
+    condition =
+      let
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+          mise.enable = false;
+        };
+      in
+      [
+        (isDirectory (getDotdir wrapper))
+        (notIsFile "${getDotdir wrapper}/lib/mise.sh")
+      ];
+  }
+  {
+    message = "if a lib-script is set then it should be generated";
+    condition =
+      let
+        libScriptFile = "${getDotdir wrapper}/lib/foo.sh";
+        libScriptContent = "echo foo";
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+          lib."foo.sh" = libScriptContent;
+        };
+      in
+      [
+        (isDirectory (getDotdir wrapper))
+        (isFile libScriptFile)
+        (fileContains libScriptFile libScriptContent)
+      ];
+  }
+  {
+    message = "if silent mode is enabled then log settings should be set";
+    condition =
+      let
+        direnvTomlFile = "${getDotdir wrapper}/direnv.toml";
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+          silent = true;
+        };
+      in
+      [
+        (isDirectory (getDotdir wrapper))
+        (isFile direnvTomlFile)
+        (fileContains direnvTomlFile "log_format")
+        (fileContains direnvTomlFile "log_filter")
+      ];
+  }
+  {
+    message = "if extraConfig is working";
+    condition =
+      let
+        direnvTomlFile = "${getDotdir wrapper}/direnv.toml";
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+          extraConfig = {
+            fooSection.fooKey = "fooValue";
+          };
+        };
+      in
+      [
+        (isDirectory (getDotdir wrapper))
+        (isFile direnvTomlFile)
+        (fileContains direnvTomlFile "\\[fooSection\\]")
+        (fileContains direnvTomlFile "fooKey.*fooValue")
+      ];
+  }
+  {
+    message = "if direnvrc is working";
+    condition =
+      let
+        direnvrcFile = "${getDotdir wrapper}/direnvrc";
+        direnvrcContent = "echo foo";
+
+        wrapper = self.wrappers.direnv.wrap {
+          inherit pkgs;
+          direnvrc = direnvrcContent;
+        };
+      in
+      [
+        (isDirectory (getDotdir wrapper))
+        (isFile direnvrcFile)
+        (fileContains direnvrcFile direnvrcContent)
+      ];
+  }
+]

--- a/wrapperModules/d/direnv/check2.nix
+++ b/wrapperModules/d/direnv/check2.nix
@@ -1,0 +1,130 @@
+{
+  pkgs,
+  self,
+  tlib,
+  ...
+}:
+
+let
+  inherit (tlib)
+    fileContains
+    isDirectory
+    isFile
+    notIsFile
+    ;
+  getDotdir = wrapper: "${wrapper}/${wrapper.configuration.configDirname}";
+in
+tlib.mkTestDrv "direnv-tests" {
+  "wrapper should output correct version" =
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+      };
+    in
+    ''
+      "${wrapper}/bin/direnv" --version | grep -q "${wrapper.version}"
+    '';
+  "if nix-direnv is enabled then lib/nix-direnv.sh should exists" =
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        nix-direnv.enable = true;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile "${getDotdir wrapper}/lib/nix-direnv.sh")
+    ];
+  "if nix-direnv is disabled then lib/nix-direnv.sh should not exist" =
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        nix-direnv.enable = false;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (notIsFile "${getDotdir wrapper}/lib/nix-direnv.sh")
+    ];
+  "if mise is enabled then lib/mise.sh should exists" =
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        mise.enable = true;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile "${getDotdir wrapper}/lib/mise.sh")
+    ];
+  "if mise is disabled then lib/mise.sh should not exist" =
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        mise.enable = false;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (notIsFile "${getDotdir wrapper}/lib/mise.sh")
+    ];
+  "if a lib-script is set then it should be generated" =
+    let
+      libScriptFile = "${getDotdir wrapper}/lib/foo.sh";
+      libScriptContent = "echo foo";
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        lib."foo.sh" = libScriptContent;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile libScriptFile)
+      (fileContains libScriptFile libScriptContent)
+    ];
+  "if silent mode is enabled then log settings should be set" =
+    let
+      direnvTomlFile = "${getDotdir wrapper}/direnv.toml";
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        silent = true;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile direnvTomlFile)
+      (fileContains direnvTomlFile "log_format")
+      (fileContains direnvTomlFile "log_filter")
+    ];
+  "if extraConfig is working" =
+    let
+      direnvTomlFile = "${getDotdir wrapper}/direnv.toml";
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        extraConfig = {
+          fooSection.fooKey = "fooValue";
+        };
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile direnvTomlFile)
+      (fileContains direnvTomlFile "\\[fooSection\\]")
+      (fileContains direnvTomlFile "fooKey.*fooValue")
+    ];
+  "if direnvrc is working" =
+    let
+      direnvrcFile = "${getDotdir wrapper}/direnvrc";
+      direnvrcContent = "echo foo";
+
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        direnvrc = direnvrcContent;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile direnvrcFile)
+      (fileContains direnvrcFile direnvrcContent)
+    ];
+}

--- a/wrapperModules/d/direnv/check3.nix
+++ b/wrapperModules/d/direnv/check3.nix
@@ -1,0 +1,140 @@
+{
+  pkgs,
+  self,
+  tlib,
+  ...
+}:
+
+let
+  inherit (tlib)
+    fileContains
+    isDirectory
+    isFile
+    notIsFile
+    test
+    ;
+  getDotdir = wrapper: "${wrapper}/${wrapper.configuration.configDirname}";
+in
+tlib.mkTestDrv "direnv-tests" [
+  (test "wrapper should output correct version" (
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+      };
+    in
+    ''
+      "${wrapper}/bin/direnv" --version | grep -q "${wrapper.version}"
+    ''
+  ))
+  (test "if nix-direnv is enabled then lib/nix-direnv.sh should exists" (
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        nix-direnv.enable = true;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile "${getDotdir wrapper}/lib/nix-direnv.sh")
+    ]
+  ))
+  (test "if nix-direnv is disabled then lib/nix-direnv.sh should not exist" (
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        nix-direnv.enable = false;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (notIsFile "${getDotdir wrapper}/lib/nix-direnv.sh")
+    ]
+  ))
+  (test "if mise is enabled then lib/mise.sh should exists" (
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        mise.enable = true;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile "${getDotdir wrapper}/lib/mise.sh")
+    ]
+  ))
+  (test "if mise is disabled then lib/mise.sh should not exist" (
+    let
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        mise.enable = false;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (notIsFile "${getDotdir wrapper}/lib/mise.sh")
+    ]
+  ))
+  (test "if a lib-script is set then it should be generated" (
+    let
+      libScriptFile = "${getDotdir wrapper}/lib/foo.sh";
+      libScriptContent = "echo foo";
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        lib."foo.sh" = libScriptContent;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile libScriptFile)
+      (fileContains libScriptFile libScriptContent)
+    ]
+  ))
+  (test "if silent mode is enabled then log settings should be set" (
+    let
+      direnvTomlFile = "${getDotdir wrapper}/direnv.toml";
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        silent = true;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile direnvTomlFile)
+      (fileContains direnvTomlFile "log_format")
+      (fileContains direnvTomlFile "log_filter")
+    ]
+  ))
+  (test "if extraConfig is working" (
+    let
+      direnvTomlFile = "${getDotdir wrapper}/direnv.toml";
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        extraConfig = {
+          fooSection.fooKey = "fooValue";
+        };
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile direnvTomlFile)
+      (fileContains direnvTomlFile "\\[fooSection\\]")
+      (fileContains direnvTomlFile "fooKey.*fooValue")
+    ]
+  ))
+  (test "if direnvrc is working" (
+    let
+      direnvrcFile = "${getDotdir wrapper}/direnvrc";
+      direnvrcContent = "echo foo";
+
+      wrapper = self.wrappers.direnv.wrap {
+        inherit pkgs;
+        direnvrc = direnvrcContent;
+      };
+    in
+    [
+      (isDirectory (getDotdir wrapper))
+      (isFile direnvrcFile)
+      (fileContains direnvrcFile direnvrcContent)
+    ]
+  ))
+]

--- a/wrapperModules/d/direnv/module.nix
+++ b/wrapperModules/d/direnv/module.nix
@@ -1,0 +1,119 @@
+{
+  config,
+  lib,
+  wlib,
+  pkgs,
+  ...
+}:
+let
+  tomlFmt = pkgs.formats.toml { };
+  direnvToml = tomlFmt.generate "direnv.toml" config.extraConfig;
+  direnvDotdir = "${config.wrapper.${config.outputName}}/${config.configDirname}";
+in
+{
+  imports = [ wlib.modules.default ];
+  options = {
+    configDirname = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.binName}-dot-dir";
+      description = "Name of the directory which is created as the dotdir in the wrapper output";
+    };
+    silent = lib.mkEnableOption "silent mode, that is, disabling direnv logging";
+    direnvrc = lib.mkOption {
+      type = lib.types.lines;
+      description = "Content of `$DIRENV_CONFIG/direnv`";
+      default = "";
+    };
+    nix-direnv = {
+      enable = lib.mkEnableOption "nix-direnv integration";
+      package = lib.mkPackageOption pkgs "nix-direnv" { };
+    };
+    mise = {
+      enable = lib.mkEnableOption "mise integration";
+      package = lib.mkPackageOption pkgs "mise" { };
+    };
+    lib = lib.mkOption {
+      type = with lib.types; attrsOf lines;
+      description = ''
+        Configuration of [extension files](https://direnv.net/#the-stdlib) 
+        that will be created at `$DIRENV_CONFIG/lib/*.sh`
+      '';
+      example = {
+        "my-lib-script.sh" = "echo 'content of my-lib-script.sh'";
+      };
+      default = { };
+    };
+    extraConfig = lib.mkOption {
+      inherit (tomlFmt) type;
+      default = { };
+      description = ''
+        Configuration of direnv.toml.
+        See <https://direnv.net/man/direnv.toml.1.html>
+      '';
+    };
+  };
+  config = {
+    package = lib.mkDefault pkgs.direnv;
+    env = {
+      # We currently do not inject `DIRENV_CONFIG` for the reasons outlined in
+      # meta.description.pre.
+
+      # **IMPORTANT** Using `placeholder "out"` here seems to cause issues if this wrapper is
+      # built inside a subWrapperModule (for example within the zshWrapper) as it refers
+      # to the build zsh output in that context. The passthru variants seems to solve this issue.
+      DIRENV_CONFIG = "${placeholder "out"}/${config.configDirname}";
+    };
+    passthru.DIRENV_CONFIG = direnvDotdir;
+    lib = {
+      "nix-direnv.sh" = lib.mkIf config.nix-direnv.enable ''
+        source ${config.nix-direnv.package}/share/nix-direnv/direnvrc
+      '';
+      "mise.sh" = lib.mkIf config.mise.enable ''
+        eval "$(${lib.getExe config.mise.package} direnv activate)"
+      '';
+    };
+    extraConfig = {
+      global = lib.mkIf (config.silent) {
+        log_format = "-";
+        log_filter = "^$";
+      };
+    };
+    constructFiles = {
+      direnvToml = {
+        content = builtins.readFile direnvToml;
+        relPath = "${config.configDirname}/direnv.toml";
+      };
+      direnvRc = {
+        content = config.direnvrc;
+        relPath = "${config.configDirname}/direnvrc";
+      };
+    }
+    // lib.mapAttrs (name: value: {
+      content = value;
+      relPath = "${config.configDirname}/lib/${name}";
+    }) config.lib;
+    meta.maintainers = [ wlib.maintainers.zenoli ];
+    meta.description.pre = ''
+      **IMPORTANT** In order to use this wrapper, `DIRENV_CONFIG` needs to be explicitly 
+      set in your shells environment:
+
+      ```shell
+      DIRENV_CONFIG="''${direnvWrapper.passthru.DIRENV_CONFIG}"
+      ```
+
+      This is because right now, direnv will use the original `direnv` binary in its shell hook
+      and not the wrapper script. So injecting `DIRENV_CONFIG` currently has no effect.
+
+      If the PR below will ever be merged, this issue can be fixed by setting:
+
+      ```nix
+      env.DIRENV_EXE_PATH = "''${placeholder "out"}/bin/direnv";
+      ```
+
+      This would make the direnv hook use the wrapper instead of the original binary and 
+      injecting `DIRENV_CONFIG` into the wrapper would start to take effect. 
+
+      https://github.com/direnv/direnv/pull/1564
+    '';
+  };
+}

--- a/wrapperModules/g/git/check.nix
+++ b/wrapperModules/g/git/check.nix
@@ -1,9 +1,9 @@
 {
   pkgs,
   self,
+  tlib,
   ...
 }:
-
 let
   gitWrapped = self.wrappers.git.wrap {
     inherit pkgs;
@@ -14,10 +14,11 @@ let
       };
     };
   };
-
+  inherit (tlib) test;
 in
-pkgs.runCommand "git-test" { } ''
-  "${gitWrapped}/bin/git" config user.name | grep -q "Test User"
-  "${gitWrapped}/bin/git" config user.email | grep -q "test@example.com"
-  touch $out
-''
+tlib.enableBySystem self.wrappers.git (
+  tlib.mkTestDrv "git-test" [
+    (test "has test user" ''"${gitWrapped}/bin/git" config user.name | grep -q "Test User"'')
+    (test "has test email" ''"${gitWrapped}/bin/git" config user.email | grep -q "test@example.com"'')
+  ]
+)


### PR DESCRIPTION
@zenoli

Thoughts on this instead?

Im worried about trying to manage the wrapper module for the user that it would lead to people making a million drvs, and also, it adds complexity points to handle that that could be better spent making them nest somewhat arbitrarily?

Here, we only accept it to check platform

I left the direnv wrapper module in as an example for you to review at least 1 usage of it

I will remove the direnv wrapper module from this PR before merging it if we go with this design.

It also takes an arbitrarily nested set of lists of conditions too

And you can call .extend and add more tests to it.

I still need to add docs for it and stuff. But what do you think? Flexible enough?