### PR TITLE
feat(wlib.genStr): now takes function as well

### DIFF
--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -607,11 +607,23 @@ in
       (builtins.attrNames attrs);
 
   /**
-    genStr :: string -> int -> string
+    `genStr` :: `string` -> `int` -> `string`
+
+    or
+
+    `genStr` :: (`int`: `string`) -> `int` -> `string`
+
+    Generates a string by repeating the input string the specified number of times,
+    or by calling the provided function with the index the specified number of times.
+  */
+  genStr = str: num: builtins.concatStringsSep "" (builtins.genList (lib.toFunction str) num);
+
+  /**
+    `repeatStr` :: `string` -> `int` -> `string`
 
     Generates a string by repeating the input string the specified number of times
   */
-  genStr = str: num: builtins.concatStringsSep "" (builtins.genList (_: str) num);
+  repeatStr = str: num: builtins.concatStringsSep "" (builtins.genList (_: str) num);
 
   /**
     Converts a Nix value to a KDL document string.

--- a/lib/toKdl.nix
+++ b/lib/toKdl.nix
@@ -30,7 +30,7 @@ let
               toVal attrs;
         in
         if isList args then lib.concatMapStringsSep " " mkAttrsOrVal args else mkAttrsOrVal args;
-      indent = wlib.genStr indent_str;
+      indent = wlib.repeatStr indent_str;
       special = lib.isFunction val;
       res = if special then lib.fix val else val;
       v = if special then res.content or null else res;

--- a/wrapperModules/m/mdbook/module.nix
+++ b/wrapperModules/m/mdbook/module.nix
@@ -105,8 +105,7 @@ let
         assert
           (node.depth or null != null) || throw "Type error: node must have depth given by sortBook function";
         let
-          genStr = str: num: builtins.concatStringsSep "" (builtins.genList (_: str) num);
-          i = genStr "  " node.depth;
+          i = wlib.repeatStr "  " node.depth;
         in
         if node.data == "title" then
           assert (node.name != null) || throw "Type error: title node must have name";


### PR DESCRIPTION
also added wlib.repeatStr which is the old genStr. The new genStr accepts both forms of argument

https://github.com/BirdeeHub/nix-wrapper-modules/pull/452#discussion_r3120872218

This is backward compatible, you do not need to change usage.

The motivation is that `builtins.genList` and `lib.genAttrs` both can receive functions as their first argument. This technically made `wlib.genStr` misnamed because it could not. Now it can!