### PR TITLE
fix(wrapperModules.yazi): fix script for generating flavors

### DIFF
--- a/wrapperModules/y/yazi/module.nix
+++ b/wrapperModules/y/yazi/module.nix
@@ -487,6 +487,7 @@ in
         mkdir -p ${lib.escapeShellArg "${config.generatedConfig.placeholder}/flavors"}
       ''
       + lib.concatMapAttrsStringSep "\n" (toLink "plugins") config.plugins
+      + "\n"
       + lib.concatMapAttrsStringSep "\n" (toLink "flavors") config.flavors;
   };
 


### PR DESCRIPTION
`config.buildCommand.makePluginsAndFlavors` is missing a newline if both plugins and flavors are used.

Before:

```sh
ln -s /nix/store/a4lvmin2zdj33d3vzswg292dnqdv78wv-source /1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9/yazi-config/plugins/time-travel.yaziln -s /home/iynaix/.config/yazi/flavors/noctalia.yazi /1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9/yazi-config/flavors/noctalia.yazi
```

After:
```sh
ln -s /nix/store/a4lvmin2zdj33d3vzswg292dnqdv78wv-source /1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9/yazi-config/plugins/time-travel.yazi
ln -s /home/iynaix/.config/yazi/flavors/noctalia.yazi /1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9/yazi-config/flavors/noctalia.yazi
```