### PR TITLE
fix(wrapperModules.niri): change extraConfig to lib.types.lines

### DIFF
--- a/wrapperModules/n/niri/module.nix
+++ b/wrapperModules/n/niri/module.nix
@@ -277,7 +277,7 @@ in
           };
           extraConfig = lib.mkOption {
             default = "";
-            type = lib.types.str;
+            type = lib.types.lines;
             description = ''
               Escape hatch string option added to the config file for
               options that might not be representable otherwise,


### PR DESCRIPTION
Use `lib.types.lines` for `extraConfig` so additional text can be appended when using .apply or .wrap.