### PR TITLE
feat(wrapperModules.mangowc): use new official mango configuration syntax

### DIFF
--- a/wrapperModules/m/mangowc/check.nix
+++ b/wrapperModules/m/mangowc/check.nix
@@ -59,6 +59,11 @@ let
       ./config.conf
     ];
 
+    autostart_sh = ''
+      # spawn terminal on startup
+      ${pkgs.lib.getExe pkgs.foot}
+    '';
+
     extraConfig = ''
       # menu and terminal
       bind=Alt,space,spawn,rofi -show drun

--- a/wrapperModules/m/mangowc/check.nix
+++ b/wrapperModules/m/mangowc/check.nix
@@ -7,11 +7,59 @@ let
   mangowcWrapped = self.wrappers.mangowc.wrap {
     inherit pkgs;
 
+    settings = {
+      # Window effects
+      blur = 1;
+      blur_optimized = 1;
+      blur_params = {
+        radius = 5;
+        num_passes = 2;
+      };
+      border_radius = 6;
+      focused_opacity = 1.0;
+
+      # Animations - use underscores for multi-part keys
+      animations = 1;
+      animation_type_open = "slide";
+      animation_type_close = "slide";
+      animation_duration_open = 400;
+      animation_duration_close = 800;
+
+      # Or use nested attrs (will be flattened with underscores)
+      animation_curve = {
+        open = "0.46,1.0,0.29,1";
+        close = "0.08,0.92,0,1";
+      };
+
+      # Use lists for duplicate keys like bind and tagrule
+      bind = [
+        "SUPER,r,reload_config"
+        "Alt,space,spawn,rofi -show drun"
+        "Alt,Return,spawn,foot"
+        "ALT,R,setkeymode,resize" # Enter resize mode
+      ];
+
+      tagrule = [
+        "id:1,layout_name:tile"
+        "id:2,layout_name:scroller"
+      ];
+
+      # Keymodes (submaps) for modal keybindings
+      keymode = {
+        resize = {
+          bind = [
+            "NONE,Left,resizewin,-10,0"
+            "NONE,Escape,setkeymode,default"
+          ];
+        };
+      };
+    };
+
     sourcedFiles = [
       ./config.conf
     ];
 
-    extraContent = ''
+    extraConfig = ''
       # menu and terminal
       bind=Alt,space,spawn,rofi -show drun
       bind=Alt,Return,spawn,${pkgs.lib.getExe pkgs.foot}

--- a/wrapperModules/m/mangowc/lib.nix
+++ b/wrapperModules/m/mangowc/lib.nix
@@ -1,0 +1,313 @@
+# Taken from https://github.com/mangowm/mango/blob/main/nix/lib.nix
+lib:
+let
+  inherit (lib)
+    attrNames
+    filterAttrs
+    foldl
+    generators
+    partition
+    removeAttrs
+    ;
+
+  inherit (lib.strings)
+    concatMapStrings
+    hasPrefix
+    ;
+
+  /**
+    Convert a structured Nix attribute set into Mango's configuration format.
+
+    This function takes a nested attribute set and converts it into Mango-compatible
+    configuration syntax, supporting top, bottom, and regular command sections.
+
+    Commands are flattened using the `flattenAttrs` function, and attributes are formatted as
+    `key = value` pairs. Lists are expanded as duplicate keys to match Mango's expected format.
+
+    Configuration:
+
+    * `topCommandsPrefixes` - A list of prefixes to define **top** commands (default: `[]`).
+    * `bottomCommandsPrefixes` - A list of prefixes to define **bottom** commands (default: `[]`).
+
+    Attention:
+
+    - The function ensures top commands appear **first** and bottom commands **last**.
+    - The generated configuration is a **single string**, suitable for writing to a config file.
+    - Lists are converted into multiple entries, ensuring compatibility with Mango.
+
+    # Inputs
+
+    Structured function argument:
+
+    : topCommandsPrefixes (optional, default: `[]`)
+      : A list of prefixes that define **top** commands. Any key starting with one of these
+        prefixes will be placed at the beginning of the configuration.
+    : bottomCommandsPrefixes (optional, default: `[]`)
+      : A list of prefixes that define **bottom** commands. Any key starting with one of these
+        prefixes will be placed at the end of the configuration.
+
+    Value:
+
+    : The attribute set to be converted to Hyprland configuration format.
+
+    # Type
+
+    ```
+    toMango :: AttrSet -> AttrSet -> String
+    ```
+
+    # Examples
+    :::{.example}
+
+    ## Basic mangowc configuration
+
+    ```nix
+    let
+      config = {
+        blur = 1;
+        blur_params_radius = 5;
+        border_radius = 6;
+        animations = 1;
+        animation_duration_open = 400;
+      };
+    in lib.toMango {} config
+    ```
+
+    **Output:**
+    ```
+    animations = 1
+    animation_duration_open = 400
+    blur = 1
+    blur_params_radius = 5
+    border_radius = 6
+    ```
+
+    ## Using nested attributes
+
+    ```nix
+    let
+      config = {
+        blur = 1;
+        blur_params = {
+          radius = 5;
+          num_passes = 2;
+          noise = 0.02;
+        };
+        animation_curve = {
+          open = "0.46,1.0,0.29,1";
+          close = "0.08,0.92,0,1";
+        };
+      };
+    in lib.toMango {} config
+    ```
+
+    **Output:**
+    ```
+    animation_curve_close = 0.08,0.92,0,1
+    animation_curve_open = 0.46,1.0,0.29,1
+    blur = 1
+    blur_params_noise = 0.02
+    blur_params_num_passes = 2
+    blur_params_radius = 5
+    ```
+
+    ## Using lists for duplicate keys
+
+    ```nix
+    let
+      config = {
+        bind = [
+          "SUPER,r,reload_config"
+          "Alt,space,spawn,rofi -show drun"
+          "Alt,Return,spawn,foot"
+        ];
+        tagrule = [
+          "id:1,layout_name:tile"
+          "id:2,layout_name:scroller"
+        ];
+      };
+    in lib.toMango {} config
+    ```
+
+    **Output:**
+    ```
+    bind = SUPER,r,reload_config
+    bind = Alt,space,spawn,rofi -show drun
+    bind = Alt,Return,spawn,foot
+    tagrule = id:1,layout_name:tile
+    tagrule = id:2,layout_name:scroller
+    ```
+
+    ## Using keymodes (submaps)
+
+    ```nix
+    let
+      config = {
+        bind = [
+          "SUPER,Q,killclient"
+          "ALT,R,setkeymode,resize"
+        ];
+        keymode = {
+          resize = {
+            bind = [
+              "NONE,Left,resizewin,-10,0"
+              "NONE,Right,resizewin,10,0"
+              "NONE,Escape,setkeymode,default"
+            ];
+          };
+        };
+      };
+    in lib.toMango {} config
+    ```
+
+    **Output:**
+    ```
+    bind = SUPER,Q,killclient
+    bind = ALT,R,setkeymode,resize
+
+    keymode = resize
+    bind = NONE,Left,resizewin,-10,0
+    bind = NONE,Right,resizewin,10,0
+    bind = NONE,Escape,setkeymode,default
+    ```
+
+    :::
+  */
+  toMango =
+    {
+      topCommandsPrefixes ? [ ],
+      bottomCommandsPrefixes ? [ ],
+    }:
+    attrs:
+    let
+      toMango' =
+        attrs:
+        let
+          # Specially configured `toKeyValue` generator with support for duplicate keys
+          # and a legible key-value separator.
+          mkCommands = generators.toKeyValue {
+            mkKeyValue = generators.mkKeyValueDefault { } " = ";
+            listsAsDuplicateKeys = true;
+            indent = ""; # No indent, since we don't have nesting
+          };
+
+          # Extract keymode definitions if they exist
+          keymodes = attrs.keymode or { };
+          attrsWithoutKeymodes = removeAttrs attrs [ "keymode" ];
+
+          # Generate keymode blocks
+          # Format: keymode=name\nbind=...\nbind=...\n
+          mkKeymodeBlock =
+            name: modeAttrs:
+            let
+              modeCommands = flattenAttrs (p: k: "${p}_${k}") modeAttrs;
+            in
+            "keymode = ${name}\n${mkCommands modeCommands}";
+
+          keymodeBlocks =
+            if keymodes == { } then
+              ""
+            else
+              "\n" + concatMapStrings (name: mkKeymodeBlock name keymodes.${name} + "\n") (attrNames keymodes);
+
+          # Flatten the attrset, combining keys in a "path" like `"a_b_c" = "x"`.
+          # Uses `flattenAttrs` with an underscore separator.
+          commands = flattenAttrs (p: k: "${p}_${k}") attrsWithoutKeymodes;
+
+          # General filtering function to check if a key starts with any prefix in a given list.
+          filterCommands = list: n: foldl (acc: prefix: acc || hasPrefix prefix n) false list;
+
+          # Partition keys into top commands and the rest
+          result = partition (filterCommands topCommandsPrefixes) (attrNames commands);
+          topCommands = filterAttrs (n: _: builtins.elem n result.right) commands;
+          remainingCommands = removeAttrs commands result.right;
+
+          # Partition remaining commands into bottom commands and regular commands
+          result2 = partition (filterCommands bottomCommandsPrefixes) result.wrong;
+          bottomCommands = filterAttrs (n: _: builtins.elem n result2.right) remainingCommands;
+          regularCommands = removeAttrs remainingCommands result2.right;
+        in
+        # Concatenate strings from mapping `mkCommands` over top, regular, and bottom commands.
+        # Keymodes are appended at the end.
+        concatMapStrings mkCommands [
+          topCommands
+          regularCommands
+          bottomCommands
+        ]
+        + keymodeBlocks;
+    in
+    toMango' attrs;
+
+  /**
+    Flatten a nested attribute set into a flat attribute set, using a custom key separator function.
+
+    This function recursively traverses a nested attribute set and produces a flat attribute set
+    where keys are joined using a user-defined function (`pred`). It allows transforming deeply
+    nested structures into a single-level attribute set while preserving key-value relationships.
+
+    Configuration:
+
+    * `pred` - A function `(string -> string -> string)` defining how keys should be concatenated.
+
+    # Inputs
+
+    Structured function argument:
+
+    : pred (required)
+      : A function that determines how parent and child keys should be combined into a single key.
+        It takes a `prefix` (parent key) and `key` (current key) and returns the joined key.
+
+    Value:
+
+    : The nested attribute set to be flattened.
+
+    # Type
+
+    ```
+    flattenAttrs :: (String -> String -> String) -> AttrSet -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+
+    ```nix
+    let
+      nested = {
+        a = "3";
+        b = { c = "4"; d = "5"; };
+      };
+
+      separator = (prefix: key: "${prefix}.${key}");  # Use dot notation
+    in lib.flattenAttrs separator nested
+    ```
+
+    **Output:**
+    ```nix
+    {
+      "a" = "3";
+      "b.c" = "4";
+      "b.d" = "5";
+    }
+    ```
+
+    :::
+  */
+  flattenAttrs =
+    pred: attrs:
+    let
+      flattenAttrs' =
+        prefix: attrs:
+        builtins.foldl' (
+          acc: key:
+          let
+            value = attrs.${key};
+            newKey = if prefix == "" then key else pred prefix key;
+          in
+          acc // (if builtins.isAttrs value then flattenAttrs' newKey value else { "${newKey}" = value; })
+        ) { } (builtins.attrNames attrs);
+    in
+    flattenAttrs' "" attrs;
+in
+{
+  inherit flattenAttrs toMango;
+}

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -245,7 +245,7 @@
       relPath = "autostart_sh";
       content = config.autostart_sh;
       builder = ''
-        mkdir -p "$(dirname "$2")" && printf '%s\n' '#!/bin/bash' > "$2" && cat "$1" >> "$2" && chmod +x "$2"
+        mkdir -p "$(dirname "$2")" && printf '%s\n' ${lib.escapeShellArg "#!${pkgs.bash}${pkgs.bash.shellPath}"} > "$2" && cat "$1" >> "$2" && chmod +x "$2"
       '';
     };
 

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -234,7 +234,15 @@
           + "\n"
           + extraConfig
           + "\n"
-          + lib.optionalString (config.autostart_sh != "") "\nexec-once=~/.config/mango/autostart.sh\n";
+          + lib.optionalString (
+            config.autostart_sh != ""
+          ) "\nexec-once=${config.constructFiles.autostart_sh.path}\n";
+    };
+
+    constructFiles.autostart_sh = {
+      relPath = "autostart_sh";
+      content = config.autostart_sh;
+      builder = ''mkdir -p "$(dirname "$2")" && cp "$1" "$2" && chmod +x "$2"'';
     };
 
     flags."-c" = config.configFile.path;

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -192,6 +192,7 @@
           Deprecated, please use 'extraConfig' instead
         '';
         default = "";
+        internal = true;
       };
     };
 

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -244,7 +244,9 @@
     constructFiles.autostart_sh = {
       relPath = "autostart_sh";
       content = config.autostart_sh;
-      builder = ''mkdir -p "$(dirname "$2")" && cp "$1" "$2" && chmod +x "$2"'';
+      builder = ''
+        mkdir -p "$(dirname "$2")" && printf '%s\n' '#!/bin/bash' > "$2" && cat "$1" >> "$2" && chmod +x "$2"
+      '';
     };
 
     flags."-c" = config.configFile.path;

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -10,7 +10,12 @@
 
   options =
     let
-      inherit (lib) mkOption types;
+      inherit (lib)
+        literalExpression
+        mkOption
+        mkOptionDefault
+        types
+        ;
     in
     {
       settings = mkOption {
@@ -38,16 +43,14 @@
           should be written as lists. Variables and colors names should be
           quoted. See <https://mangowc.vercel.app/docs> for more examples.
 
-          ::: {.note}
-          This option uses a structured format that is converted to Mango's
+          Note: This option uses a structured format that is converted to Mango's
           configuration syntax. Nested attributes are flattened with underscore separators.
           For example: `animation.duration_open = 400` becomes `animation_duration_open = 400`
 
           Keymodes (submaps) are supported via the special `keymode` attribute. Each keymode
           is a nested attribute set under `keymode` that contains its own bindings.
-          :::
         '';
-        example = lib.literalExpression ''
+        example = literalExpression ''
           {
             # Window effects
             blur = 1;
@@ -102,7 +105,7 @@
         type = types.lines;
         default = "";
         description = ''
-          Extra configuration lines to add to `~/.config/mango/config.conf`.
+          Extra configuration lines to add to the end of the generated config file.
           This is useful for advanced configurations that don't fit the structured
           settings format, or for options that aren't yet supported by the module.
         '';
@@ -113,7 +116,7 @@
       };
 
       topPrefixes = mkOption {
-        type = with lib.types; listOf str;
+        type = with types; listOf str;
         default = [ ];
         description = ''
           List of prefixes for attributes that should appear at the top of the config file.
@@ -123,7 +126,7 @@
       };
 
       bottomPrefixes = mkOption {
-        type = with lib.types; listOf str;
+        type = with types; listOf str;
         default = [ ];
         description = ''
           List of prefixes for attributes that should appear at the bottom of the config file.
@@ -154,7 +157,7 @@
           Paths to files that will be sourced at the top of the generated config file.
         '';
         default = [ ];
-        example = ''
+        example = literalExpression ''
           [
             ./config.conf
             ./binds.conf
@@ -165,23 +168,22 @@
 
       configFile = mkOption {
         type = wlib.types.file {
-          path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+          path = mkOptionDefault config.constructFiles.generatedConfig.path;
         };
         default = { };
         description = ''
-          Config file that mango will set as its config file.
+          The config file that mango will set as its primary config file.
+          By default, this file will be generated from whatever the other options are set to.
 
-          Note: If configFile.path or configFile.content is set, it will overwrite the effects of the `sourcedFiles` and `extraContent` options.
+          Note: If `configFile.path` is set, it will be used INSTEAD of the generated configuration. The generated file will still be created, however, and you can source it. Add your path to the `sourcedFiles` option if you want the generated config to still apply.
+
+          If `configFile.content` is set, it will replace the contents of the generated config file entirely. Use the `extraConfig` option if you want the generated config to still apply.
         '';
-        example = ''
+        example = literalExpression ''
           {
             path = ./config.conf;
             # or
-            content = ''''
-              # menu and terminal
-              bind=Alt,space,spawn,rofi -show drun
-              bind=Alt,Return,spawn,foot
-            '''';
+            content = "bind=Alt,space,spawn,rofi -show drun";
           }
         '';
       };

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -8,61 +8,194 @@
 {
   imports = [ wlib.modules.default ];
 
-  options = {
-    sourcedFiles = lib.mkOption {
-      type = lib.types.listOf wlib.types.stringable;
-      description = ''
-        Paths to files that will be sourced at the top of the generated config file.
-      '';
-      default = [ ];
-      example = ''
-        [
-          ./config.conf
-          ./binds.conf
-          ./theme.conf
-        ]
-      '';
-    };
+  options =
+    let
+      inherit (lib) mkOption types;
+    in
+    {
+      settings = mkOption {
+        type =
+          with types;
+          let
+            valueType =
+              nullOr (oneOf [
+                bool
+                int
+                float
+                str
+                path
+                (attrsOf valueType)
+                (listOf valueType)
+              ])
+              // {
+                description = "Mango configuration value";
+              };
+          in
+          valueType;
+        default = { };
+        description = ''
+          Mango configuration written in Nix. Entries with the same key
+          should be written as lists. Variables and colors names should be
+          quoted. See <https://mangowc.vercel.app/docs> for more examples.
 
-    configFile = lib.mkOption {
-      type = wlib.types.file {
-        path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+          ::: {.note}
+          This option uses a structured format that is converted to Mango's
+          configuration syntax. Nested attributes are flattened with underscore separators.
+          For example: `animation.duration_open = 400` becomes `animation_duration_open = 400`
+
+          Keymodes (submaps) are supported via the special `keymode` attribute. Each keymode
+          is a nested attribute set under `keymode` that contains its own bindings.
+          :::
+        '';
+        example = lib.literalExpression ''
+          {
+            # Window effects
+            blur = 1;
+            blur_optimized = 1;
+            blur_params = {
+              radius = 5;
+              num_passes = 2;
+            };
+            border_radius = 6;
+            focused_opacity = 1.0;
+
+            # Animations - use underscores for multi-part keys
+            animations = 1;
+            animation_type_open = "slide";
+            animation_type_close = "slide";
+            animation_duration_open = 400;
+            animation_duration_close = 800;
+
+            # Or use nested attrs (will be flattened with underscores)
+            animation_curve = {
+              open = "0.46,1.0,0.29,1";
+              close = "0.08,0.92,0,1";
+            };
+
+            # Use lists for duplicate keys like bind and tagrule
+            bind = [
+              "SUPER,r,reload_config"
+              "Alt,space,spawn,rofi -show drun"
+              "Alt,Return,spawn,foot"
+              "ALT,R,setkeymode,resize"  # Enter resize mode
+            ];
+
+            tagrule = [
+              "id:1,layout_name:tile"
+              "id:2,layout_name:scroller"
+            ];
+
+            # Keymodes (submaps) for modal keybindings
+            keymode = {
+              resize = {
+                bind = [
+                  "NONE,Left,resizewin,-10,0"
+                  "NONE,Escape,setkeymode,default"
+                ];
+              };
+            };
+          }
+        '';
       };
-      default = { };
-      description = ''
-        Config file that mango will set as its config file.
 
-        Note: If configFile.path or configFile.content is set, it will overwrite the effects of the `sourcedFiles` and `extraContent` options.
-      '';
-      example = ''
-        {
-          path = ./config.conf;
-          # or
-          content = ''''
-            # menu and terminal
-            bind=Alt,space,spawn,rofi -show drun
-            bind=Alt,Return,spawn,foot
-          '''';
-        }
-      '';
-    };
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Extra configuration lines to add to `~/.config/mango/config.conf`.
+          This is useful for advanced configurations that don't fit the structured
+          settings format, or for options that aren't yet supported by the module.
+        '';
+        example = ''
+          # Advanced config that doesn't fit structured format
+          special_option = 1
+        '';
+      };
 
-    extraContent = lib.mkOption {
-      type = lib.types.lines;
-      description = ''
-        Configurations that will be appended to the end of the generated configuration file.
-      '';
-      default = "";
-      example = ''
-        # menu and terminal
-        bind=Alt,space,spawn,rofi -show drun
-        bind=Alt,Return,spawn,foot
-      '';
+      topPrefixes = mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        description = ''
+          List of prefixes for attributes that should appear at the top of the config file.
+          Attributes starting with these prefixes will be sorted to the beginning.
+        '';
+        example = [ "source" ];
+      };
+
+      bottomPrefixes = mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        description = ''
+          List of prefixes for attributes that should appear at the bottom of the config file.
+          Attributes starting with these prefixes will be sorted to the end.
+        '';
+        example = [ "source" ];
+      };
+
+      autostart_sh = mkOption {
+        description = ''
+          Shell script to run on mango startup. No shebang needed.
+
+          When this option is set, the script will be written to
+          `~/.config/mango/autostart.sh` and an `exec-once` line
+          will be automatically added to the config to execute it.
+        '';
+        type = types.lines;
+        default = "";
+        example = ''
+          waybar &
+          dunst &
+        '';
+      };
+
+      sourcedFiles = mkOption {
+        type = types.listOf wlib.types.stringable;
+        description = ''
+          Paths to files that will be sourced at the top of the generated config file.
+        '';
+        default = [ ];
+        example = ''
+          [
+            ./config.conf
+            ./binds.conf
+            ./theme.conf
+          ]
+        '';
+      };
+
+      configFile = mkOption {
+        type = wlib.types.file {
+          path = lib.mkOptionDefault config.constructFiles.generatedConfig.path;
+        };
+        default = { };
+        description = ''
+          Config file that mango will set as its config file.
+
+          Note: If configFile.path or configFile.content is set, it will overwrite the effects of the `sourcedFiles` and `extraContent` options.
+        '';
+        example = ''
+          {
+            path = ./config.conf;
+            # or
+            content = ''''
+              # menu and terminal
+              bind=Alt,space,spawn,rofi -show drun
+              bind=Alt,Return,spawn,foot
+            '''';
+          }
+        '';
+      };
+
+      extraContent = mkOption {
+        type = types.lines;
+        description = ''
+          Deprecated, please use 'extraConfig' instead
+        '';
+        default = "";
+      };
     };
-  };
 
   config = {
-    package = lib.mkDefault pkgs.mangowc;
     # Gives an error when using a bad config.
     drv.installPhase = ''
       runHook preInstall
@@ -77,18 +210,37 @@
           config.configFile.content
         else
           let
+            settingsString =
+              let
+                inherit (import ./lib.nix lib) toMango;
+              in
+              toMango {
+                topCommandsPrefixes = config.topPrefixes;
+                bottomCommandsPrefixes = config.bottomPrefixes;
+              } config.settings;
             isImpurePath = s: builtins.isString s && !builtins.hasContext s;
             sourcedFileToSourceExpression =
               sourcedFile:
               if isImpurePath sourcedFile then "source-optional=${sourcedFile}" else "source=${sourcedFile}";
+            extraConfig =
+              if config.extraContent or "" != "" then
+                lib.warn "wrapperModules.mangowc: config.extraContent is deprecated, please use config.extraConfig instead" (
+                  config.extraContent
+                )
+              else
+                config.extraConfig;
           in
           (lib.strings.concatMapStringsSep "\n" sourcedFileToSourceExpression config.sourcedFiles)
           + "\n"
-          + config.extraContent;
+          + settingsString
+          + "\n"
+          + extraConfig
+          + "\n"
+          + lib.optionalString (config.autostart_sh != "") "\nexec-once=~/.config/mango/autostart.sh\n";
     };
 
     flags."-c" = config.configFile.path;
-
+    package = lib.mkDefault pkgs.mangowc;
     passthru.providedSessions = config.package.passthru.providedSessions;
 
     meta.platforms = lib.platforms.linux;

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -188,9 +188,6 @@
 
       extraContent = mkOption {
         type = types.lines;
-        description = ''
-          Deprecated, please use 'extraConfig' instead
-        '';
         default = "";
         internal = true;
       };

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -175,9 +175,9 @@
           The config file that mango will set as its primary config file.
           By default, this file will be generated from whatever the other options are set to.
 
-          Note: If `configFile.path` is set, it will be used INSTEAD of the generated configuration. The generated file will still be created, however, and you can source it. Add your path to the `sourcedFiles` option if you want the generated config to still apply.
+          Note: If `configFile.path` is set, it will be used INSTEAD of the generated configuration. The generated file will still be created, however, and you can source it. If you don't want the generated config to get overwritten, add the path you want to use to the `sourcedFiles` option and don't set `configFile.path`.
 
-          If `configFile.content` is set, it will replace the contents of the generated config file entirely. Use the `extraConfig` option if you want the generated config to still apply.
+          If `configFile.content` is set, it will replace the contents of the generated config file entirely. If you don't want the generated config to get overwritten, set the `extraConfig` option and don't set `configFile.content`.
         '';
         example = literalExpression ''
           {


### PR DESCRIPTION
Mango recently added a nix -> mango converter to their home-manager module, figured it'd be nice to copy here

This _should_ make it so that anyone that uses the home-manager module can just copy-paste their config and it will still work
It also shouldn't impact anyone using the nix wrapper currently (aside from the renaming of `extraContent` to `extraConfig`)