### PR TITLE
feat(scheduled deprecations): wrapperModules output now has modules in it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
         }
       ) self.nixosModules;
       wrappers = lib.mapAttrs (_: v: (self.lib.evalModule v).config) self.lib.wrapperModules;
+      wrapperModules = self.lib.wrapperModules;
       wrappedModules = lib.mapAttrs (
         _:
         lib.warn ''
@@ -43,18 +44,6 @@
           This will be the last time these output names are changing, as a flake-parts module has been added for users to import.
 
           This output will be removed on August 31, 2026
-        ''
-      ) self.wrappers;
-      wrapperModules = lib.mapAttrs (
-        _:
-        lib.warn ''
-          Attention: `inputs.nix-wrapper-modules.wrapperModules` is deprecated, use `inputs.nix-wrapper-modules.wrappers` instead
-
-          Apologies for any inconvenience this has caused. But the title `wrapperModules` should be specific to ones you can import.
-
-          In the future, rather than being removed, this will be replaced by the unevaluated wrapper modules from `wlib.wrapperModules`
-
-          This output will be replaced with module paths on April 30, 2026
         ''
       ) self.wrappers;
       formatter = forAllSystems (

--- a/lib/core.nix
+++ b/lib/core.nix
@@ -298,7 +298,6 @@ in
                 };
               };
             }
-            config.overmods
           ];
         }
       );
@@ -917,63 +916,5 @@ in
         This may prove useful when dealing with subWrapperModules or packages, which otherwise would not have access to some of them.
       '';
     };
-    symlinkScript = lib.mkOption {
-      type = lib.types.nullOr (
-        lib.types.functionTo (
-          lib.types.either lib.types.str (lib.types.functionTo (lib.types.attrsOf lib.types.raw))
-        )
-      );
-      internal = true;
-      default = null;
-      description = "DEPRECATED";
-    };
-    overmods = lib.mkOption {
-      type = lib.types.nullOr lib.types.deferredModule;
-      default = null;
-      internal = true;
-      description = "DEPRECATED";
-      apply =
-        x:
-        let
-          msg = ''
-            Attention: config.overmods is deprecated!
-
-            Why? You could already do it like this!
-
-            ```nix
-            { config, lib, wlib, pkgs, ... }:{
-              options.overrides = lib.mkOption {
-                type = wlib.types.seriesOf (wlib.types.spec ({ config, ... }: {
-                  options = {}; # spec types support type merging!
-                  config = {};
-                }));
-              };
-            }
-            ```
-
-            Before the addition of `wlib.types.seriesOf`,
-            trying that with `listOf` would mess up the ordering.
-
-            You could reimplement this option yourself like the following example.
-            Don't forget to declare the option you want to use for it!
-
-            ```nix
-            { config, lib, wlib, ... }:{
-              options.overrides = lib.mkOption {
-                type = wlib.types.seriesOf (wlib.types.spec (config.<desired_option_name>));
-              };
-            }
-            ```
-          '';
-        in
-        if x != null then lib.warn msg x else { };
-    };
   };
-  config.builderFunction = lib.mkIf (config.symlinkScript != null) (
-    lib.warn ''
-      Renamed option in wrapper module for ${config.binName}!
-      `config.symlinkScript` -> `config.builderFunction`
-      Please update all usages of the option to the new name.
-    '' config.symlinkScript
-  );
 }

--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -33,7 +33,6 @@ let
     isFunction
     types
     ;
-  inherit (lib.attrsets) filterAttrs;
   inherit (lib.lists) toposort;
   inherit (wlib.dag)
     isEntry
@@ -53,18 +52,6 @@ let
   mkDagEntryModule =
     settings: elemType:
     let
-      isStrict =
-        if isBool (settings.strict or null) then
-          lib.warn "dagWith `strict` setting deprecated, set freeformType from within a module passed to the modules argument instead" settings.strict
-        else
-          true;
-      extraOptions =
-        if settings ? extraOptions then
-          lib.warn
-            "Deprecated dagWith/dalWith setting: `extraOptions` set. Use `modules` list instead to provide extra options"
-            (if isAttrs (settings.extraOptions or null) then settings.extraOptions else { })
-        else
-          null;
       dataOptFn =
         if isFunction (settings.dataTypeFn or null) then
           args: { type = settings.dataTypeFn elemType args; }
@@ -77,19 +64,16 @@ let
       description = settings.description or null;
       mainField = settings.mainField or null;
       dontConvertFunctions = settings.dontConvertFunctions or null;
-      modules =
-        optionals (!isStrict) [ { freeformType = wlib.types.attrsRecursive; } ]
-        ++ [
-          (mkDagEntry {
-            dataOptFn = if isFunction (settings.dataOptFn or null) then settings.dataOptFn else dataOptFn;
-            defaultNameFn =
-              if isFunction (settings.defaultNameFn or null) then settings.defaultNameFn else null;
-            isDal = if isBool (settings.isDal or null) then settings.isDal else false;
-          })
-        ]
-        ++ optionals (elemType.name == "submodule" || elemType.name == "spec") [ dagNameModule ]
-        ++ optionals (extraOptions != null) [ { options = filterAttrs (_: v: !isBool v) extraOptions; } ]
-        ++ optionals (isList (settings.modules or null)) settings.modules;
+      modules = [
+        (mkDagEntry {
+          dataOptFn = if isFunction (settings.dataOptFn or null) then settings.dataOptFn else dataOptFn;
+          defaultNameFn =
+            if isFunction (settings.defaultNameFn or null) then settings.defaultNameFn else null;
+          isDal = if isBool (settings.isDal or null) then settings.isDal else false;
+        })
+      ]
+      ++ optionals (elemType.name == "submodule") [ dagNameModule ]
+      ++ optionals (isList (settings.modules or null)) settings.modules;
     };
 in
 {
@@ -200,7 +184,7 @@ in
     You would do this because the name argument of that submodule will receive the field it was in,
     not the one from the parent `attrsOf` type.
 
-    If you use `dagWith` or `dalWith`, this is done for you for `submodule` and `spec`.
+    If you use `dagWith` or `dalWith`, this is done for you for `submodule`
   */
   dagNameModule =
     { config, name, ... }:
@@ -665,7 +649,4 @@ in
       Payload values that will be converted into DAG entries.
   */
   entriesBefore = tag: before: entriesBetween tag before [ ];
-
-  dagOf = lib.warn "wlib.dag.dagOf deprecated. Use wlib.types.dagOf instead." wlib.types.dagOf;
-  dalOf = lib.warn "wlib.dag.dalOf deprecated. Use wlib.types.dalOf instead." wlib.types.dalOf;
 }

--- a/wrapperModules/x/xplr/module.nix
+++ b/wrapperModules/x/xplr/module.nix
@@ -9,28 +9,13 @@ let
   luaType = (pkgs.formats.lua { }).type;
   enabledDagOf = wlib.types.dagOf // {
     modules = [
-      (
-        { config, ... }:
-        {
-          options.enable = lib.mkOption {
-            type = lib.types.bool;
-            default = true;
-            description = "Enable the value";
-          };
-          options.disabled = lib.mkOption {
-            internal = true;
-            type = lib.types.nullOr lib.types.bool;
-            default = null;
-          };
-          config.enable = lib.mkIf (config.disabled != null) (
-            lib.warn ''
-              wrapperModules.xplr:
-              `plugins.<name>.disabled` is deprecated. Use `plugins.<name>.enable` instead
-              `luaInit.<name>.disabled` is deprecated. Use `luaInit.<name>.enable` instead
-            '' (!config.disabled)
-          );
-        }
-      )
+      {
+        options.enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Enable the value";
+        };
+      }
     ];
   };
   configDagOf = enabledDagOf // {


### PR DESCRIPTION
April 30th deprecations

outputs.wrapperModules now has the importable form of the wrapper module, just like the flake-parts module produces.

Some other deprecations that were added at either the same time or significantly before have also been finally removed