### PR TITLE
fix(tlib): handle singleton assertions in set form

### DIFF
--- a/ci/test-lib.nix
+++ b/ci/test-lib.nix
@@ -80,11 +80,23 @@ let
       renderAssertions =
         assertions: lib.concatMapStringsSep " &&\n" (a: "(${renderAssertion a})") assertions;
 
+      isAssertion =
+        x:
+        lib.isString x
+        || (
+          lib.isAttrs x
+          &&
+            lib.attrNames x == [
+              "cond"
+              "msg"
+            ]
+        );
+
       renderNode =
         node:
         let
           block =
-            if !(lib.isAttrs node) then
+            if lib.isList node || isAssertion node then
               renderAssertions (lib.toList node)
             else
               lib.concatMapAttrsStringSep " &&\n" (name: childNode: ''
@@ -137,12 +149,11 @@ in
     where:
 
     ```
-    TestSet :: attrsOf (TestSet | Test)
+    TestSet :: Test | attrsOf (TestSet | Test)
 
-    Test :: [ Assertion ]
+    Test :: Assertion | [ Assertion ]
 
-    Assertion :: String | { cond :: String; msg :: String; }
-    ```
+    Assertion :: String | { cond :: String; msg :: String; }    ```
 
     # Arguments
 


### PR DESCRIPTION
We did not handle of passing singleton assertions like this:

```nix
test "my-test" {
  "test description" = { cond = "some condition"; msg = "some message"; };
}
```

because they were indistinguishable from nested tests.

This is not ideal, as technically, we cannot create a test-group containing exactly two tests named "cond" and "msg" but I think it is fine.