### PR TITLE
test(makeCustomizable): refactor tests with tlib

### DIFF
--- a/ci/checks/makeCustomizable.nix
+++ b/ci/checks/makeCustomizable.nix
@@ -1,9 +1,14 @@
 {
   pkgs,
   self,
+  tlib,
   ...
 }:
 let
+  inherit (tlib)
+    areEqual
+    test
+    ;
   testfunctor = self.lib.makeCustomizable "test" { } (v: { value = v; }) { some = "args"; };
 
   testfunctor2 = testfunctor.test (lp: {
@@ -14,28 +19,17 @@ let
   });
   testfunctor4 = testfunctor3.test { again = "testing"; };
 in
-pkgs.runCommand "makeCustomizable-test" { } ''
 
-  if [ "${testfunctor.value.some}" != "args" ]; then
-    echo "FAILURE: makeCustomizable test failed (some = args)"
-    exit 1
-  fi
+test "makeCustomizable-test" [
+  (areEqual "args" testfunctor.value.some)
 
-  if [ "${testfunctor2.value.some}" != "args" ] || [ "${testfunctor2.value.more}" != "args" ]; then
-    echo "FAILURE: makeCustomizable test 2 failed (some = args, more = args)"
-    exit 1
-  fi
+  (areEqual "args" testfunctor2.value.some)
+  (areEqual "args" testfunctor2.value.more)
 
-  if [ "${testfunctor3.value.some}" != "args" ] || [ "${testfunctor3.value.more}" != "with overriding" ]; then
-    echo "FAILURE: makeCustomizable test 3 failed (some = args, more = with overriding)"
-    exit 1
-  fi
+  (areEqual "args" testfunctor3.value.some)
+  (areEqual "with overriding" testfunctor3.value.more)
 
-  if [ "${testfunctor4.value.some}" != "args" ] || [ "${testfunctor4.value.more}" != "with overriding" ] || [ "${testfunctor4.value.again}" != "testing" ]; then
-    echo "FAILURE: makeCustomizable test 4 failed (some = args, more = with overriding, again = testing)"
-    exit 1
-  fi
-
-  echo "SUCCESS: makeCustomizable test passed (including multi-level chaining)"
-  touch $out
-''
+  (areEqual "args" testfunctor4.value.some)
+  (areEqual "with overriding" testfunctor4.value.more)
+  (areEqual "testing" testfunctor4.value.again)
+]


### PR DESCRIPTION
I just wanted to check how well it works to use tlib for non-wrapper tests.

If I have time I can also do the other ones. If you don't want to risk touching all of the checks, or don't want to review all of it we can also leave them as they are and just use tlib going forward.