### PR TITLE
feat(devShell): init

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _site
 **/result-*
 **/repl-result-*
+.direnv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,9 +125,6 @@ Example:
 
 `nix fmt`
 
-## Tests
-
-`nix flake check -Lv ./ci`
 
 ## Run Site Generator Locally
 
@@ -137,6 +134,15 @@ or
 
 `nix run ./ci#docs`
 
+> [!NOTE]
+> We also provide a `shell.nix` with a `docs` command that does exactly this.
+> Start the devshell (`nix develop`) and type `docs --help` for more info on how to use it.
+
+## Tests
+
+
+`nix flake check -Lv ./ci`
+
 To run the tests for an individual wrapper only, run
 
 `nix build ./ci#checks.{system}.wrapperModule-{name}`
@@ -144,6 +150,10 @@ To run the tests for an individual wrapper only, run
 Example (neovim on `x86_64-linux`):
 
 `nix build ./ci#checks.x86_64-linux.wrapperModule-neovim`
+
+> [!NOTE]
+> We also provide a `shell.nix` with a `check` command that does exactly this.
+> Start the devshell (`nix develop`) and type `check --help` for more info on how to use it.
 
 ## Writing Tests
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,15 @@
         name: value: self.lib.getInstallModule { inherit name value; }
       ) self.lib.wrapperModules;
       homeModules = self.nixosModules;
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import (inputs.pkgs.path or inputs.nixpkgs or <nixpkgs>) { inherit system; };
+        in
+        {
+          default = import ./shell.nix { inherit pkgs; };
+        }
+      );
       formatter = forAllSystems (
         system:
         (

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,89 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  docs = pkgs.writeShellApplication {
+    name = "docs";
+    runtimeInputs = [ pkgs.python3 ];
+    text = ''
+      usage() {
+        echo "Usage: docs [OPTION]"
+        echo ""
+        echo "Builds and serves the documentation."
+        echo ""
+        echo "Options:"
+        echo "  -p, --port PORT  Port to serve on (default: 1337)"
+        echo "  -h, --help       Show this help"
+      }
+
+      port=1337
+
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          -h|--help)
+            usage
+            exit 0
+            ;;
+          -p|--port)
+            port="$2"
+            shift 2
+            ;;
+          *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        esac
+      done
+
+      nix run ./ci#docs -- ./_site && cd _site && python3 -m http.server "$port"
+    '';
+  };
+
+  test = pkgs.writeShellScriptBin "check" ''
+    usage() {
+      echo "Usage: check [OPTION] [NAME]"
+      echo ""
+      echo "With no arguments, runs all checks."
+      echo ""
+      echo "Options:"
+      echo "  -w, --wrapperModule NAME  Run check wrapperModule-NAME"
+      echo "  -l, --wlib NAME           Run check wlib-NAME"
+      echo "  -m, --module NAME         Run check module-NAME"
+      echo "  NAME                      Run check NAME"
+      echo "  -h, --help                Show this help"
+    }
+
+    if [ $# -eq 0 ]; then
+      nix flake check -Lv ./ci
+      exit 0
+    fi
+
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      -w|--wrapperModule)
+        nix build "./ci#checks.${system}.wrapperModule-$2"
+        ;;
+      -l|--wlib)
+        nix build "./ci#checks.${system}.wlib-$2"
+        ;;
+      -m|--module)
+        nix build "./ci#checks.${system}.module-$2"
+        ;;
+      *)
+        nix build "./ci#checks.${system}.$1"
+        ;;
+    esac && echo "Test passed!"
+  '';
+in
+pkgs.mkShell {
+  packages = [
+    docs
+    test
+  ];
+}


### PR DESCRIPTION
Mostly written by claude. I found it annoying to always remember these, so this made things a bit more convenient for me. Maybe it is for others too.

If you think this is bloat I have no hard feelings. You can better judge whether those things will change often, in which case I'd rather not want to maintain those :-)

It adds a shell.nix providing two helper scripts:

- `docs` for running the docs generator and serving it at localhost:1337
- `checks` for either running all checks, or specific wrapperModule/wlib/module checks if specified.

It uses direnv to automatically load/unload these scripts.
Direnv is of course not required and it can still be used with `nix develop` or `nix-shell` (we can also remove .envrc entirely)