### PR TITLE
feat(core.install): add hjem support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
         name: value: self.lib.getInstallModule { inherit name value; }
       ) self.lib.wrapperModules;
       homeModules = self.nixosModules;
+      hjemModules = self.nixosModules;
       devShells = forAllSystems (system: {
         default = import ./shell.nix { pkgs = getPkgs system; };
       });

--- a/lib/core.nix
+++ b/lib/core.nix
@@ -184,6 +184,15 @@ in
           in
           lib.mkIf cfg.enable [ cfg.wrapper ];
       };
+    hjem =
+      { config, ... }:
+      {
+        config.packages =
+          let
+            cfg = args.config.install.getWrapperConfig config;
+          in
+          lib.mkIf cfg.enable [ cfg.wrapper ];
+      };
     nixos =
       { config, ... }:
       {


### PR DESCRIPTION
Created an entry for the `hjem` class under `install.modules` and added an `hjemModules` convenience flake output.