### PR TITLE
feat(ci): only render wrapper specific options

### DIFF
--- a/ci/docs/default.nix
+++ b/ci/docs/default.nix
@@ -77,16 +77,23 @@ in
         includeCore = false;
         inherit (config) warningsAreErrors;
         moduleStartsOpen = _: _: true;
-        descriptionStartsOpen = _: _: _: true;
-        descriptionIncluded = _: _: _: true;
+        descriptionStartsOpen =
+          _: _: _:
+          true;
+        descriptionIncluded =
+          _: _: _:
+          true;
       };
     in
     builtins.mapAttrs (buildModuleDocs commonArgs) wlib.modules
     // {
-      default = buildModuleDocs (commonArgs // {
-        excludeFiles = builtins.attrValues defaultSubModules;
-        warningsAreErrors = false;
-      }) "default" wlib.modules.default;
+      default = buildModuleDocs (
+        commonArgs
+        // {
+          excludeFiles = builtins.attrValues defaultSubModules;
+          warningsAreErrors = false;
+        }
+      ) "default" wlib.modules.default;
     };
   config.drv.wrapper_docs = builtins.mapAttrs (buildModuleDocs {
     prefix = "wlib.wrapperModules.";
@@ -195,12 +202,14 @@ in
         src = "${placeholder "generated"}/module_docs/default.md";
         subchapters = lib.pipe config.drv.module_docs [
           (v: removeAttrs v [ "default" ])
-          (lib.mapAttrsToList (n: _: {
-            name = "`wlib.modules.${n}`";
-            data = "numbered";
-            path = "modules/${n}.md";
-            src = "${placeholder "generated"}/module_docs/${n}.md";
-          }))
+          (lib.mapAttrsToList (
+            n: _: {
+              name = "`wlib.modules.${n}`";
+              data = "numbered";
+              path = "modules/${n}.md";
+              src = "${placeholder "generated"}/module_docs/${n}.md";
+            }
+          ))
         ];
       }
       {
@@ -210,12 +219,14 @@ in
         src = ./md/helper-modules.md;
         subchapters = lib.pipe config.drv.module_docs [
           (v: removeAttrs v (builtins.attrNames wlib.modules))
-          (lib.mapAttrsToList (n: _: {
-            name = n;
-            data = "numbered";
-            path = "modules/${n}.md";
-            src = "${placeholder "generated"}/module_docs/${n}.md";
-          }))
+          (lib.mapAttrsToList (
+            n: _: {
+              name = n;
+              data = "numbered";
+              path = "modules/${n}.md";
+              src = "${placeholder "generated"}/module_docs/${n}.md";
+            }
+          ))
         ];
       }
       {

--- a/ci/docs/default.nix
+++ b/ci/docs/default.nix
@@ -68,19 +68,26 @@ in
       echo "$(echo "$decoded" | jq -r '.value')" > "$generated/module_docs/$(echo "$decoded" | jq -r '.key').md"
     done
   '';
-  config.drv.module_docs = builtins.mapAttrs (buildModuleDocs {
-    prefix = "wlib.modules.";
-    package = pkgs.hello;
-    includeCore = false;
-    inherit (config) warningsAreErrors;
-    moduleStartsOpen = _: _: true;
-    descriptionStartsOpen =
-      _: _: _:
-      true;
-    descriptionIncluded =
-      _: _: _:
-      true;
-  }) wlib.modules;
+  config.drv.module_docs =
+    let
+      defaultSubModules = removeAttrs wlib.modules [ "default" ];
+      commonArgs = {
+        prefix = "wlib.modules.";
+        package = pkgs.hello;
+        includeCore = false;
+        inherit (config) warningsAreErrors;
+        moduleStartsOpen = _: _: true;
+        descriptionStartsOpen = _: _: _: true;
+        descriptionIncluded = _: _: _: true;
+      };
+    in
+    builtins.mapAttrs (buildModuleDocs commonArgs) wlib.modules
+    // {
+      default = buildModuleDocs (commonArgs // {
+        excludeFiles = builtins.attrValues defaultSubModules;
+        warningsAreErrors = false;
+      }) "default" wlib.modules.default;
+    };
   config.drv.wrapper_docs = builtins.mapAttrs (buildModuleDocs {
     prefix = "wlib.wrapperModules.";
     includeCore = false;
@@ -186,6 +193,15 @@ in
         data = "numbered";
         path = "modules/default.md";
         src = "${placeholder "generated"}/module_docs/default.md";
+        subchapters = lib.pipe config.drv.module_docs [
+          (v: removeAttrs v [ "default" ])
+          (lib.mapAttrsToList (n: _: {
+            name = "`wlib.modules.${n}`";
+            data = "numbered";
+            path = "modules/${n}.md";
+            src = "${placeholder "generated"}/module_docs/${n}.md";
+          }))
+        ];
       }
       {
         name = "Helper Modules";
@@ -193,9 +209,8 @@ in
         path = "md/helper-modules.md";
         src = ./md/helper-modules.md;
         subchapters = lib.pipe config.drv.module_docs [
-          (v: removeAttrs v [ "default" ])
-          builtins.attrNames
-          (map (n: {
+          (v: removeAttrs v (builtins.attrNames wlib.modules))
+          (lib.mapAttrsToList (n: _: {
             name = n;
             data = "numbered";
             path = "modules/${n}.md";

--- a/ci/docs/default.nix
+++ b/ci/docs/default.nix
@@ -13,6 +13,7 @@ let
       title ? null,
       package ? null,
       includeCore ? true,
+      excludeFiles ? [ ],
       descriptionStartsOpen ? null,
       descriptionIncluded ? null,
       moduleStartsOpen ? null,
@@ -30,7 +31,7 @@ let
         }
       ]
       // {
-        inherit includeCore warningsAreErrors;
+        inherit includeCore warningsAreErrors excludeFiles;
         ${if descriptionStartsOpen != null then "descriptionStartsOpen" else null} = descriptionStartsOpen;
         ${if descriptionIncluded != null then "descriptionIncluded" else null} = descriptionIncluded;
         ${if moduleStartsOpen != null then "moduleStartsOpen" else null} = moduleStartsOpen;
@@ -82,6 +83,8 @@ in
   }) wlib.modules;
   config.drv.wrapper_docs = builtins.mapAttrs (buildModuleDocs {
     prefix = "wlib.wrapperModules.";
+    includeCore = false;
+    excludeFiles = builtins.attrValues wlib.modules;
     inherit (config) warningsAreErrors;
   }) wlib.wrapperModules;
   config.drv.core_docs = buildModuleDocs {
@@ -98,7 +101,11 @@ in
         title = "nix-wrapper-modules";
         description = "Make wrapper derivations with the module system! Use the existing modules, or write your own!";
       };
-      output.html.git-repository-url = "https://github.com/BirdeeHub/nix-wrapper-modules";
+      output.html = {
+        git-repository-url = "https://github.com/BirdeeHub/nix-wrapper-modules";
+        fold.enable = true;
+        fold.level = 0;
+      };
     };
     summary = [
       {

--- a/ci/docs/per-mod/normopts.nix
+++ b/ci/docs/per-mod/normopts.nix
@@ -8,6 +8,7 @@
   prefix ? false,
   transform ? null,
   includeCore ? true,
+  excludeFiles ? [ ],
   ...
 }:
 let
@@ -187,10 +188,18 @@ lib.pipe modules-by-meta [
   ))
   (
     normed:
-    if builtins.isBool includeCore && includeCore == true then
-      normed
+    let
+      excludeFileStrs = map toString excludeFiles;
+      withCore =
+        if builtins.isBool includeCore && includeCore == true then
+          normed
+        else
+          builtins.filter (v: v.file != wlib.core) normed;
+    in
+    if excludeFileStrs == [ ] then
+      withCore
     else
-      builtins.filter (v: v.file != wlib.core) normed
+      builtins.filter (v: !builtins.elem (toString v.file) excludeFileStrs) withCore
   )
   (
     v:

--- a/ci/docs/per-mod/normopts.nix
+++ b/ci/docs/per-mod/normopts.nix
@@ -174,17 +174,25 @@ in
 lib.pipe modules-by-meta [
   (builtins.concatMap (
     v:
-    lib.optional (internal ? "${v.file}" || hidden ? "${v.file}" || visible ? "${v.file}") (
-      v
-      // {
-        ${if internal ? "${v.file}" then "internal" else null} =
-          internal.${v.file} ++ lib.optional (v.file == anon_name) (internal.${anon_name} or [ ]);
-        ${if hidden ? "${v.file}" then "hidden" else null} =
-          hidden.${v.file} ++ lib.optional (v.file == anon_name) (hidden.${anon_name} or [ ]);
-        ${if visible ? "${v.file}" then "visible" else null} =
-          visible.${v.file} ++ lib.optional (v.file == anon_name) (visible.${anon_name} or [ ]);
-      }
-    )
+    lib.optional
+      (
+        internal ? "${v.file}"
+        || hidden ? "${v.file}"
+        || visible ? "${v.file}"
+        || v.description.pre or "" != ""
+        || v.description.post or "" != ""
+      )
+      (
+        v
+        // {
+          ${if internal ? "${v.file}" then "internal" else null} =
+            internal.${v.file} ++ lib.optional (v.file == anon_name) (internal.${anon_name} or [ ]);
+          ${if hidden ? "${v.file}" then "hidden" else null} =
+            hidden.${v.file} ++ lib.optional (v.file == anon_name) (hidden.${anon_name} or [ ]);
+          ${if visible ? "${v.file}" then "visible" else null} =
+            visible.${v.file} ++ lib.optional (v.file == anon_name) (visible.${anon_name} or [ ]);
+        }
+      )
   ))
   (
     normed:

--- a/ci/docs/per-mod/rendermd.nix
+++ b/ci/docs/per-mod/rendermd.nix
@@ -106,39 +106,41 @@ let
     let
       moduleNotes = extraModuleNotes i mod;
     in
-    lib.optionalString (mod.visible or [ ] != [ ]) ''
-      ## ${nameFromModule mod}
-      ${lib.optionalString (builtins.isString moduleNotes && moduleNotes != "") "\n${moduleNotes}\n"}
-      ${lib.optionalString (mod.description.pre or "" != "" && descriptionIncluded "pre" i mod) ''
-        <details${if descriptionStartsOpen "pre" i mod then " open" else ""}>
-          <summary></summary>
+    lib.optionalString
+      (mod.visible or [ ] != [ ] || mod.description.pre or "" != "" || mod.description.post or "" != "")
+      ''
+        ## ${nameFromModule mod}
+        ${lib.optionalString (builtins.isString moduleNotes && moduleNotes != "") "\n${moduleNotes}\n"}
+        ${lib.optionalString (mod.description.pre or "" != "" && descriptionIncluded "pre" i mod) ''
+          <details${if descriptionStartsOpen "pre" i mod then " open" else ""}>
+            <summary></summary>
 
-        ${mod.description.pre}
+          ${mod.description.pre}
 
-        </details>
+          </details>
 
-      ''}
-      ${lib.optionalString (mod.visible or [ ] != [ ]) ''
-        <details${if moduleStartsOpen i mod then " open" else ""}>
-          <summary></summary>
+        ''}
+        ${lib.optionalString (mod.visible or [ ] != [ ]) ''
+          <details${if moduleStartsOpen i mod then " open" else ""}>
+            <summary></summary>
 
-        ${lib.pipe mod.visible [
-          (map renderOption)
-          (builtins.concatStringsSep "\n\n")
-        ]}
+          ${lib.pipe mod.visible [
+            (map renderOption)
+            (builtins.concatStringsSep "\n\n")
+          ]}
 
-        </details>
-      ''}
-      ${lib.optionalString (mod.description.post or "" != "" && descriptionIncluded "post" i mod) ''
+          </details>
+        ''}
+        ${lib.optionalString (mod.description.post or "" != "" && descriptionIncluded "post" i mod) ''
 
-        <details${if descriptionStartsOpen "post" i mod then " open" else ""}>
-          <summary></summary>
+          <details${if descriptionStartsOpen "post" i mod then " open" else ""}>
+            <summary></summary>
 
-        ${mod.description.post}
+          ${mod.description.post}
 
-        </details>
-      ''}
-    '';
+          </details>
+        ''}
+      '';
 in
 builtins.unsafeDiscardStringContext (
   builtins.concatStringsSep "\n\n" (lib.imap1 renderModule normed)

--- a/ci/docs/per-mod/rendermd.nix
+++ b/ci/docs/per-mod/rendermd.nix
@@ -9,6 +9,7 @@
 {
   options,
   includeCore ? true,
+  excludeFiles ? [ ],
   transform ? null,
   prefix ? false,
   warningsAreErrors ? true,
@@ -59,6 +60,7 @@ let
           transform
           prefix
           includeCore
+          excludeFiles
           ;
       });
   mkOptField =

--- a/modules/default/module.nix
+++ b/modules/default/module.nix
@@ -6,4 +6,13 @@
     wlib.modules.makeWrapper
   ];
   config.meta.maintainers = [ wlib.maintainers.birdee ];
+  config.meta.description = ''
+    `wlib.modules.default` is a convenience module that simply imports the following three helper modules:
+
+    - `wlib.modules.symlinkScript`
+    - `wlib.modules.constructFiles`
+    - `wlib.modules.makeWrapper`
+
+    Each of these is documented in its own subchapter.
+  '';
 }


### PR DESCRIPTION
**Disclaimer**: This was completely one-shotted by Claude. 
The only thing I did manually was adding [collapsible sections](https://rust-lang.github.io/mdBook/format/configuration/renderers.html?highlight=fold#outputhtmlfold).

I did not understand the whole nix-docs to mdbook logic, so I tried giving claude a try (and was surprised it coming up with a rather concise solution). 

Putting aside if the code is actually good - I think having only the wrapperModule specific options rendered in the docs makes them a lot more usable. Of course ideally we would have a link to the core/default options at the bottom of each wrapperModule.


## Before:

<img width="927" height="1013" alt="image" src="https://github.com/user-attachments/assets/372e43de-618b-4b4c-874e-a9fcb37489f7" />

## After:

<img width="936" height="1005" alt="image" src="https://github.com/user-attachments/assets/9dab634b-551c-44f8-9d2f-f0c7ec67177f" />
