### PR TITLE
docs(wrapperModules.wezterm): small doc improvements

### DIFF
--- a/wrapperModules/w/wezterm/module.nix
+++ b/wrapperModules/w/wezterm/module.nix
@@ -57,7 +57,7 @@
       The `defaultval` in this call will be returned if the item you specified does not exist in the luaInfo table.
       This allows you to use a config that works with and without the wrapper's setup.
 
-      To access config values form the final wrapper derivation you can use `''${placeholder config.outputName}` to point to it.
+      To access config values from the final wrapper derivation you can use `''${placeholder config.outputName}` to point to it.
 
       By default, the result of `require('nix-info')` is used as your wezterm config file, see the "wezterm.lua" option for details.
     '';

--- a/wrapperModules/w/wezterm/module.nix
+++ b/wrapperModules/w/wezterm/module.nix
@@ -24,9 +24,10 @@
 
       Note that for this wrapper, the packages will be taken from `config.lua.pkgs`, so make sure that they are available from the derivation you set for the `lua` option.
     '';
-    example = ''
-      # String used to prevent function displaying as `<function>`
+    example = lib.literalMD ''
+      ```nix
       luaEnv = (lp: [ lp.luafilesystem ]);
+      ```
     '';
   };
   options."wezterm.lua" = lib.mkOption {
@@ -48,15 +49,31 @@
     inherit (pkgs.formats.lua { }) type;
     default = { };
     description = ''
-      Defines attributes which are converted to Lua. The converted values are made available to the wezterm config as the result of calling `require('nix-info')`.
-
+      Defines attributes which are converted to Lua.
+      The converted values are made available to the wezterm config as the result of calling `require('nix-info')`.
       The conversion to Lua uses `lib.generators.toLua` which accepts anything other than uncalled nix functions.
 
-      `''${placeholder config.outputName}` is usable here and will point to the final wrapper derivation
+      You can also access specific values from this option by calling `require('nix-info')(defaultval, "path", "to", "item")` in your config.
+      The `defaultval` in this call will be returned if the item you specified does not exist in the luaInfo table.
+      This allows you to use a config that works with and without the wrapper's setup.
 
-      You may also call `require('nix-info')(defaultval, "path", "to", "item")`. This will help prevent indexing errors when querying nested values which may not exist.
+      To access config values form the final wrapper derivation you can use `''${placeholder config.outputName}` to point to it.
 
       By default, the result of `require('nix-info')` is used as your wezterm config file, see the "wezterm.lua" option for details.
+    '';
+    example = lib.literalMD ''
+      ```nix
+      {
+        keys = [
+          {
+            key = "F12";
+            mods = "SUPER|CTRL|ALT|SHIFT";
+            # To get lua expressions, pass a string to lib.generators.mkLuaInline
+            action = lib.generators.mkLuaInline "wezterm.action.Nop";
+          }
+        ];
+      };
+      ```
     '';
   };
   config.constructFiles."wezterm.lua" = {

--- a/wrapperModules/w/wezterm/module.nix
+++ b/wrapperModules/w/wezterm/module.nix
@@ -16,13 +16,17 @@
     type = wlib.types.withPackagesType;
     default = (lp: [ ]);
     description = ''
-      extra lua packages to add to the lua environment for wezterm
+      Extra lua packages to add to the lua environment for wezterm.
+      These packages will be added to package.path and package.cpath in the lua environment.
 
-      value is to be a function from `config.lua.pkgs` to list
+      The value must be a function that can be passed to the [`lua.withPackages`](https://nixos.org/manual/nixpkgs/stable/#lua.withpackages-function) function from `nixpkgs`.
+      This function should take a single argument, and return a list of packages defined as attributes of the argument (see example).
 
-      `config.lua.withPackages config.luaEnv`
-
-      The result will be added to package.path and package.cpath
+      Note that for this wrapper, the packages will be taken from `config.lua.pkgs`, so make sure that they are available from the derivation you set for the `lua` option.
+    '';
+    example = ''
+      # String used to prevent function displaying as `<function>`
+      luaEnv = (lp: [ lp.luafilesystem ]);
     '';
   };
   options."wezterm.lua" = lib.mkOption {
@@ -31,25 +35,28 @@
       content = lib.mkOptionDefault "return require('nix-info')";
     };
     default = { };
-    description = "The wezterm config file. provide `.content`, or `.path`";
+    description = ''
+      The wezterm config file.
+
+      By default the content of the `luaInfo` option is used and nothing has to be provided here.
+
+      If you wish to use your own file instead, provide either the `.content`, or `.path` attributes to this option.
+      You can still use the `luaInfo` option in this case, see its description for details.
+    '';
   };
   options.luaInfo = lib.mkOption {
     inherit (pkgs.formats.lua { }) type;
     default = { };
     description = ''
-      anything other than uncalled nix functions can be put into this option, 
-      within your `"wezterm.lua"`, you will be able to call `require('nix-info')`
-      and get the values as lua values
+      Defines attributes which are converted to Lua. The converted values are made available to the wezterm config as the result of calling `require('nix-info')`.
 
-      the default `"wezterm.lua"`.content value is `return require('nix-info')`
+      The conversion to Lua uses `lib.generators.toLua` which accepts anything other than uncalled nix functions.
 
-      This means, by default, this will act like your wezterm config file, unless you want to add some lua in between there.
+      `''${placeholder config.outputName}` is usable here and will point to the final wrapper derivation
 
-      `''${placeholder config.outputName}` is useable here and will point to the final wrapper derivation
+      You may also call `require('nix-info')(defaultval, "path", "to", "item")`. This will help prevent indexing errors when querying nested values which may not exist.
 
-      You may also call `require('nix-info')(defaultval, "path", "to", "item")`
-
-      This will help prevent indexing errors when querying nested values which may not exist.
+      By default, the result of `require('nix-info')` is used as your wezterm config file, see the "wezterm.lua" option for details.
     '';
   };
   config.constructFiles."wezterm.lua" = {


### PR DESCRIPTION
I made some edits to the wezterm option docs to make them clearer (in my opinion), particularly if you start reading the docs at one of the later options.

I couldn't quite figure out the use cases for `${placeholder config.outputName}` and `require('nix-info')(defaultval, "path", "to", "item")` in the luaInfo option. If you could provide a use-case for them, I will add an example for the option which includes the use-cases with comments.