### PR TITLE
fix(wrapperModules.fish): fish sub processes of fish were excluding config

### DIFF
--- a/wrapperModules/f/fish/module.nix
+++ b/wrapperModules/f/fish/module.nix
@@ -234,7 +234,7 @@ in
           if set -q __wrapped_fish_sourced
             return
           end
-          set -gx __wrapped_fish_sourced 1
+          set -g __wrapped_fish_sourced 1
           fish_add_path --path ${dirOf config.wrapperPaths.placeholder}
         '';
 


### PR DESCRIPTION
addresses https://github.com/BirdeeHub/nix-wrapper-modules/issues/511

Thanks to @adrian-gierakowski for identifying the problem and the fix