### PR TITLE
feat(modules.constructFiles): passAsContent

### DIFF
--- a/modules/constructFiles/module.nix
+++ b/modules/constructFiles/module.nix
@@ -68,9 +68,24 @@
                 relative output path within the named output to create the file (no leading slash)
               '';
             };
+            passAsContent = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                This option controls the value passed as `$1` to the `.builder` command
+
+                If false, `$1` will contain the path to the input file
+
+                If true, `$1` will contain the content of the input file
+
+                It is recommended to use `true` when `config.drv.__structuredAttrs = true`
+                and `false` otherwise for performance,
+                unless you specifically need one or the other for your `.builder` command.
+              '';
+            };
             builder = lib.mkOption {
               type = lib.types.str;
-              default = ''mkdir -p "$(dirname "$2")" && cp "$1" "$2"'';
+              default = if config.passAsContent or false then ''echo "$1" > "$2"'' else ''cp "$1" "$2"'';
               description = ''
                 the command used to build the file.
 
@@ -129,12 +144,40 @@
     ];
     data =
       let
-        constructFile = name: path: builder: /* bash */ ''
+        constructFile = name: path: builder: asContent: /* bash */ ''
           constructFile() {
             ${builder}
           }
-          local sourceDrvVarToConstruct=${lib.escapeShellArg "${name}Path"}
-          constructFile "''${!sourceDrvVarToConstruct}" ${lib.escapeShellArg path}
+          mkdir -p "$(dirname ${lib.escapeShellArg path})"
+          if [ -n "$__structuredAttrs" ]; then
+            ${
+              if asContent then # bash
+                ''constructFile "''$${name}" ${lib.escapeShellArg path}''
+              # bash
+              else
+                ''
+                  local tempfile="$(mktemp)"
+                  echo "''$${name}" > "$tempfile"
+                  constructFile "$tempfile" ${lib.escapeShellArg path}
+                ''
+            }
+          else
+            ${
+              if asContent then
+                # If we just use $<name> directly, we will be subject to ARG_MAX limits
+                # bash
+                ''
+                  local sourceDrvVarToConstruct=${lib.escapeShellArg "${name}Path"}
+                  constructFile "$(cat "''${!sourceDrvVarToConstruct}")" ${lib.escapeShellArg path}
+                ''
+              # bash
+              else
+                ''
+                  local sourceDrvVarToConstruct=${lib.escapeShellArg "${name}Path"}
+                  constructFile "''${!sourceDrvVarToConstruct}" ${lib.escapeShellArg path}
+                ''
+            }
+          fi
         '';
       in
       ''
@@ -147,9 +190,10 @@
                 path,
                 builder,
                 key,
+                passAsContent,
                 ...
               }:
-              constructFile key path builder
+              constructFile key path builder passAsContent
             ))
             (
               v:

--- a/wrapperModules/a/alacritty/module.nix
+++ b/wrapperModules/a/alacritty/module.nix
@@ -24,7 +24,7 @@ in
   config.constructFiles.generatedConfig = {
     content = builtins.toJSON config.settings;
     relPath = "${config.binName}-config.toml";
-    builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+    builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
   };
   config.package = lib.mkDefault pkgs.alacritty;
   config.meta.maintainers = [ wlib.maintainers.birdee ];

--- a/wrapperModules/a/atuin/module.nix
+++ b/wrapperModules/a/atuin/module.nix
@@ -38,13 +38,13 @@ in
       generatedConfig = {
         content = builtins.toJSON config.settings;
         relPath = "${config.binName}-config/config.toml";
-        builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+        builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
       };
       generatedServerConfig = {
         content = builtins.toJSON config.server-settings;
         output = lib.mkOverride 0 config.constructFiles.generatedConfig.output;
         relPath = lib.mkOverride 0 "${dirOf config.constructFiles.generatedConfig.relPath}/server.toml";
-        builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+        builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
       };
     };
     wrapperVariants.atuin-server = { };

--- a/wrapperModules/b/bottom/module.nix
+++ b/wrapperModules/b/bottom/module.nix
@@ -30,7 +30,7 @@ in
     constructFiles.generatedConfig = {
       content = builtins.toJSON config.settings;
       relPath = "${config.binName}-config.toml";
-      builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+      builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     };
     meta.maintainers = [ wlib.maintainers.rachitvrma ];
   };

--- a/wrapperModules/b/btop/module.nix
+++ b/wrapperModules/b/btop/module.nix
@@ -138,8 +138,7 @@ in
     relPath = lib.mkOverride 0 "${config.binName}-themes/${n}.theme";
     output = lib.mkOverride 0 config.configDrvOutput;
     ${if builtins.isPath v || lib.isStorePath v then null else "content"} = v;
-    ${if builtins.isPath v || lib.isStorePath v then "builder" else null} =
-      ''mkdir -p "$(dirname "$2")" && cp ${v} "$2"'';
+    ${if builtins.isPath v || lib.isStorePath v then "builder" else null} = ''cp ${v} "$2"'';
   }) config.themes;
 
   meta.maintainers = [ wlib.maintainers.ameer ];

--- a/wrapperModules/e/eww/module.nix
+++ b/wrapperModules/e/eww/module.nix
@@ -66,7 +66,7 @@
       output = lib.mkOverride 0 config.constructFiles.yuck.output;
       relPath = lib.mkOverride 0 "${dirOf config.constructFiles.yuck.relPath}/eww.${config.style.format}";
       ${if config.style.path or null != null then "builder" else null} =
-        ''mkdir -p "$(dirname "$2")" && ln -s "${config.style.path}" "$2"'';
+        ''ln -s "${config.style.path}" "$2"'';
     };
 
     flags."--config" = dirOf config.constructFiles.yuck.path;

--- a/wrapperModules/h/halloy/module.nix
+++ b/wrapperModules/h/halloy/module.nix
@@ -94,7 +94,7 @@ in
         content = builtins.toJSON config.settings;
         relPath = lib.mkOverride 0 "${config.binName}-config/halloy/config.toml";
         output = lib.mkOverride 0 config.generatedConfig.output;
-        builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+        builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
       };
     }
     // lib.pipe config.themes [
@@ -112,11 +112,11 @@ in
               "";
           builder =
             if builtins.isString theme then
-              ''mkdir -p "$(dirname "$2")" && cp "$1" "$2"''
+              ''cp "$1" "$2"''
             else if builtins.isPath theme || lib.isStorePath theme then
-              ''mkdir -p "$(dirname "$2")" && cp ${theme} "$2"''
+              ''cp ${theme} "$2"''
             else
-              ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+              ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
         }
       ))
     ];

--- a/wrapperModules/h/helix/module.nix
+++ b/wrapperModules/h/helix/module.nix
@@ -92,7 +92,6 @@ in
       output = lib.mkOverride 0 config.generatedConfig.output;
       content = builtins.toJSON config.settings;
       builder = ''
-        mkdir -p "$(dirname "$2")" && \
         ${pkgs.remarshal}/bin/json2toml "$1" "$2" && \
         cat "$extraSettingsPath" >> "$2"
       '';
@@ -101,7 +100,7 @@ in
       relPath = lib.mkOverride 0 "${config.binName}-config/helix/languages.toml";
       output = lib.mkOverride 0 config.generatedConfig.output;
       content = builtins.toJSON config.languages;
-      builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+      builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     };
     ignore = lib.mkIf (config.ignores != [ ]) {
       relPath = lib.mkOverride 0 "${config.binName}-config/helix/ignore";
@@ -118,7 +117,7 @@ in
         output = lib.mkOverride 0 config.generatedConfig.output;
         content = if builtins.isString theme then theme else builtins.toJSON theme;
         ${if builtins.isString theme then null else "builder"} =
-          ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+          ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
       }
     ))
   ];

--- a/wrapperModules/h/himalaya/module.nix
+++ b/wrapperModules/h/himalaya/module.nix
@@ -26,7 +26,7 @@ in
       generatedConfig = {
         relPath = "${config.binName}-config.toml";
         content = builtins.toJSON config.settings;
-        builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+        builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
       };
     };
 

--- a/wrapperModules/j/jujutsu/module.nix
+++ b/wrapperModules/j/jujutsu/module.nix
@@ -29,7 +29,7 @@ in
     constructFiles.generatedConfig = {
       content = builtins.toJSON config.settings;
       relPath = "${config.binName}-config.toml";
-      builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+      builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     };
 
     meta.maintainers = [ wlib.maintainers.birdee ];

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -245,7 +245,7 @@
       relPath = "autostart_sh";
       content = config.autostart_sh;
       builder = ''
-        mkdir -p "$(dirname "$2")" && printf '%s\n' ${lib.escapeShellArg "#!${pkgs.bash}${pkgs.bash.shellPath}"} > "$2" && cat "$1" >> "$2" && chmod +x "$2"
+        printf '%s\n' ${lib.escapeShellArg "#!${pkgs.bash}${pkgs.bash.shellPath}"} > "$2" && cat "$1" >> "$2" && chmod +x "$2"
       '';
     };
 

--- a/wrapperModules/m/mpv/module.nix
+++ b/wrapperModules/m/mpv/module.nix
@@ -292,8 +292,7 @@ in
           content = if builtins.isString (v.content or null) then v.content else "";
           output = lib.mkOverride 0 config.constructFiles.generatedConfig.output;
           relPath = lib.mkOverride 0 "${dirOf config.constructFiles.generatedConfig.relPath}/${name}";
-          ${if v.path or null != null then "builder" else null} =
-            ''mkdir -p "$(dirname "$2")" && ln -s "${v.path}" "$2"'';
+          ${if v.path or null != null then "builder" else null} = ''ln -s "${v.path}" "$2"'';
         }
       ))
     ]
@@ -305,8 +304,7 @@ in
           content = if builtins.isString (v.content or null) then v.content else "";
           output = lib.mkOverride 0 config.constructFiles.generatedConfig.output;
           relPath = lib.mkOverride 0 "${dirOf config.constructFiles.generatedConfig.relPath}/scripts/${name}";
-          ${if v.path or null != null then "builder" else null} =
-            ''mkdir -p "$(dirname "$2")" && ln -s "${v.path}" "$2"'';
+          ${if v.path or null != null then "builder" else null} = ''ln -s "${v.path}" "$2"'';
         }
       ))
     ]

--- a/wrapperModules/n/noctalia-shell/module.nix
+++ b/wrapperModules/n/noctalia-shell/module.nix
@@ -330,7 +330,7 @@ in
     dump-noctalia-shell = lib.mkIf config.enableDumpScript {
       key = "dumpNoctaliaShell";
       relPath = "bin/dump-noctalia-shell";
-      builder = ''mkdir -p "$(dirname "$2")" && cp "$1" "$2" && chmod +x "$2"'';
+      builder = ''cp "$1" "$2" && chmod +x "$2"'';
       content = ''
         #!${pkgs.bash}/bin/bash
         ${config.wrapperPaths.placeholder} ipc call state all > /tmp/noctalia.json && \
@@ -340,7 +340,7 @@ in
     copy-noctalia-shell-config = lib.mkIf (config.outOfStoreConfig != null) {
       key = "copyNoctaliaShellConfig";
       relPath = "bin/copy-noctalia-shell-config";
-      builder = ''mkdir -p "$(dirname "$2")" && cp "$1" "$2" && chmod +x "$2"'';
+      builder = ''cp "$1" "$2" && chmod +x "$2"'';
       content = ''
         #!${pkgs.bash}/bin/bash
         mkdir -p ${config.outOfStoreConfig} && \
@@ -376,7 +376,7 @@ in
       relPath = lib.mkOverride 0 "${config.generatedConfigDirname}/user-templates.toml";
       output = lib.mkOverride 0 config.configDrvOutput;
       content = builtins.toJSON config.user-templates;
-      builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+      builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     };
   }
   // lib.pipe config.preInstalledPlugins [
@@ -389,7 +389,7 @@ in
         relPath = lib.mkOverride 0 "${config.generatedConfigDirname}/plugins/${name}/settings.json";
         output = lib.mkOverride 0 config.configDrvOutput;
         content = builtins.toJSON value;
-        builder = ''mkdir -p "$(dirname "$2")" && cp -f "$1" "$2"'';
+        builder = ''cp -f "$1" "$2"'';
       }
     ))
   ];

--- a/wrapperModules/o/ov/module.nix
+++ b/wrapperModules/o/ov/module.nix
@@ -26,7 +26,7 @@ in
   config.constructFiles.generatedConfig = {
     content = builtins.toJSON config.settings;
     relPath = "${config.binName}-config.yaml";
-    builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2yaml "$1" "$2"'';
+    builder = ''${pkgs.remarshal}/bin/json2yaml "$1" "$2"'';
   };
   config.package = lib.mkDefault pkgs.ov;
   config.meta.maintainers = [ wlib.maintainers.rencire ];

--- a/wrapperModules/s/starship/module.nix
+++ b/wrapperModules/s/starship/module.nix
@@ -89,7 +89,6 @@ in
         # Merges all specified presets TOML files and the TOML file generated
         # from nix settings using tomlq
         + ''
-          mkdir -p "$(dirname "$2")"
           ${pkgs.yq}/bin/tomlq -s -t 'reduce .[] as $item ({}; . * $item)' \
           ${lib.concatStringsSep " " orderedSettings} > "$2"
         '';

--- a/wrapperModules/t/tealdeer/module.nix
+++ b/wrapperModules/t/tealdeer/module.nix
@@ -26,7 +26,7 @@ in
   config.constructFiles.generatedConfig = {
     content = builtins.toJSON config.settings;
     relPath = "${config.binName}-config.toml";
-    builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+    builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
   };
   config.package = lib.mkDefault pkgs.tealdeer;
   meta.maintainers = [ wlib.maintainers.birdee ];

--- a/wrapperModules/t/tmux/module.nix
+++ b/wrapperModules/t/tmux/module.nix
@@ -273,71 +273,72 @@ in
     };
   };
   config = {
-    flags = {
-      "-f" = "${pkgs.writeText "tmux.conf" # tmux
-        ''
-          ${lib.optionalString config.sourceSensible ''
-            # ============================================= #
-            # Start with defaults from the Sensible plugin  #
-            # --------------------------------------------- #
-            run-shell ${pkgs.tmuxPlugins.sensible.rtp}
-            # ============================================= #
-          ''}
-          unbind C-b
-          set-option -g prefix ${config.prefix}
-          set -g prefix ${config.prefix}
-          bind -N "Send the prefix key through to the application" \
-            ${config.prefix} send-prefix
+    constructFiles.generatedConfig = {
+      relPath = "tmux.conf";
+      content = ''
+        ${lib.optionalString config.sourceSensible ''
+          # ============================================= #
+          # Start with defaults from the Sensible plugin  #
+          # --------------------------------------------- #
+          run-shell ${pkgs.tmuxPlugins.sensible.rtp}
+          # ============================================= #
+        ''}
+        unbind C-b
+        set-option -g prefix ${config.prefix}
+        set -g prefix ${config.prefix}
+        bind -N "Send the prefix key through to the application" \
+          ${config.prefix} send-prefix
 
-          set -g display-panes-colour ${config.displayPanesColour}
-          set -g default-terminal ${config.terminal}
-          ${lib.optionalString (config.shell != null) ''
-            set  -g default-shell "${config.shell}"
-          ''}
-          ${addPassthruVars config.updateEnvironment}
-          ${addGlobalVars config.setEnvironment}
-          ${lib.optionalString (config.terminalOverrides != null) ''
-            set -ga terminal-overrides "${config.terminalOverrides}"
-          ''}
+        set -g display-panes-colour ${config.displayPanesColour}
+        set -g default-terminal ${config.terminal}
+        ${lib.optionalString (config.shell != null) ''
+          set  -g default-shell "${config.shell}"
+        ''}
+        ${addPassthruVars config.updateEnvironment}
+        ${addGlobalVars config.setEnvironment}
+        ${lib.optionalString (config.terminalOverrides != null) ''
+          set -ga terminal-overrides "${config.terminalOverrides}"
+        ''}
 
-          set -g base-index ${toString config.baseIndex}
-          setw -g pane-base-index ${toString config.paneBaseIndex}
+        set -g base-index ${toString config.baseIndex}
+        setw -g pane-base-index ${toString config.paneBaseIndex}
 
-          set -g mouse ${tmux_bool_conv config.mouse}
-          setw -g aggressive-resize ${tmux_bool_conv config.aggressiveResize}
-          setw -g clock-mode-style ${if config.clock24 then "24" else "12"}
-          set -s escape-time ${toString config.escapeTime}
-          set -g history-limit ${toString config.historyLimit}
-          set -gq allow-passthrough ${tmux_bool_conv config.allowPassthrough}
-          set -g visual-activity ${tmux_bool_conv config.visualActivity}
+        set -g mouse ${tmux_bool_conv config.mouse}
+        setw -g aggressive-resize ${tmux_bool_conv config.aggressiveResize}
+        setw -g clock-mode-style ${if config.clock24 then "24" else "12"}
+        set -s escape-time ${toString config.escapeTime}
+        set -g history-limit ${toString config.historyLimit}
+        set -gq allow-passthrough ${tmux_bool_conv config.allowPassthrough}
+        set -g visual-activity ${tmux_bool_conv config.visualActivity}
 
-          set -g status-keys ${config.statusKeys}
-          set -g mode-keys   ${config.modeKeys}
+        set -g status-keys ${config.statusKeys}
+        set -g mode-keys   ${config.modeKeys}
 
-          ${lib.optionalString config.vimVisualKeys ''
-            bind-key -T copy-mode-vi 'v' send -X begin-selection
-            bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
-          ''}
+        ${lib.optionalString config.vimVisualKeys ''
+          bind-key -T copy-mode-vi 'v' send -X begin-selection
+          bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
+        ''}
 
-          ${lib.optionalString config.disableConfirmationPrompt ''
-            bind-key -N "Kill the current window" & kill-window
-            bind-key -N "Kill the current pane" x kill-pane
-          ''}
+        ${lib.optionalString config.disableConfirmationPrompt ''
+          bind-key -N "Kill the current window" & kill-window
+          bind-key -N "Kill the current pane" x kill-pane
+        ''}
 
-          # ============================================== #
+        # ============================================== #
 
-          ${config.configBefore}
+        ${config.configBefore}
 
-          # ============================================== #
+        # ============================================== #
 
-          ${configPlugins config.plugins}
+        ${configPlugins config.plugins}
 
-          # ============================================== #
+        # ============================================== #
 
-          ${config.configAfter}
-        ''
-      }";
+        ${config.configAfter}
+
+      '';
     };
+    flags."-f" = config.constructFiles.generatedConfig.path;
     runShell = lib.mkIf config.secureSocket [
       ''export TMUX_TMPDIR=''${TMUX_TMPDIR:-''${XDG_RUNTIME_DIR:-"/run/user/$(id -u)"}}''
     ];

--- a/wrapperModules/x/xplr/module.nix
+++ b/wrapperModules/x/xplr/module.nix
@@ -221,7 +221,6 @@ in
           ${nixInit}
         '';
       builder = ''
-        mkdir -p "$(dirname "$2")"
         { [ -e "$1" ] && cat "$1" || echo "$nixLuaInit"; }${
           if hasFnl then " | ${pkgs.luajitPackages.fennel}/bin/fennel --compile - " else " "
         }> "$2"

--- a/wrapperModules/y/yazi/module.nix
+++ b/wrapperModules/y/yazi/module.nix
@@ -509,7 +509,7 @@ in
         # redefine builder to convert the result to toml.
         # This is how pkgs.format.toml works
         # https://github.com/NixOS/nixpkgs/blob/27298c9e6596851fe781e04e54704d705d91f38b/pkgs/pkgs-lib/formats.nix#L455-L477
-        builder = ''mkdir -p "$(dirname "$2")" && ${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+        builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
       })
       {
         yazi = config.settings.yazi;

--- a/wrapperModules/z/zsh/zshenv.nix
+++ b/wrapperModules/z/zsh/zshenv.nix
@@ -197,7 +197,6 @@ in
       (config.zshenv.content or "")
     ];
     builder = ''
-      mkdir -p "$(dirname "$2")"
       echo ${lib.escapeShellArg baseZshenvP1} > "$2"
       ${wrapcmd wrapperInit}
       ${wrapperBuild}


### PR DESCRIPTION
This commit fixes __structuredAttrs + this option as mentioned here https://github.com/BirdeeHub/nix-wrapper-modules/discussions/514

It also adds a new option, passAsContent to choose what the builder option recieves as arg $1

It also removes the need to `mkdir -p "$(dirname "$2")"` when redefining builder for constructFiles