### PR TITLE
perf(modules.constructFiles): $var not subject to ARG_MAX in this scenario

### DIFF
--- a/modules/constructFiles/module.nix
+++ b/modules/constructFiles/module.nix
@@ -164,14 +164,10 @@
           else
             ${
               if asContent then
-                # If we just use $<name> directly, we will be subject to ARG_MAX limits
                 # bash
-                ''
-                  local sourceDrvVarToConstruct=${lib.escapeShellArg "${name}Path"}
-                  constructFile "$(cat "''${!sourceDrvVarToConstruct}")" ${lib.escapeShellArg path}
-                ''
-              # bash
+                ''constructFile "''$${name}" ${lib.escapeShellArg path}''
               else
+                # bash
                 ''
                   local sourceDrvVarToConstruct=${lib.escapeShellArg "${name}Path"}
                   constructFile "''${!sourceDrvVarToConstruct}" ${lib.escapeShellArg path}


### PR DESCRIPTION
bad testing lead to `constructFiles.<name>.passAsContent` without use of `__structuredAttrs` being slightly slower than necessary.

If passAsFile is used for a derivation-provided arg, this is sufficient to remove ARG_MAX limits.

This means we do not need to actually read from the file for passAsContent, as the stdenv did that for us.

This was missed in testing because both ways work fine.