### PR TITLE
fix(wrapperModules.mpv): script.<name>.opts fix

### DIFF
--- a/wrapperModules/m/mpv/module.nix
+++ b/wrapperModules/m/mpv/module.nix
@@ -273,12 +273,12 @@ in
         lib.mkIf (scriptsData != [ ] && (config.configDir == { } || !builtins.isAttrs config.configDir))
           {
             sep = "=";
-            ifs = ":";
+            ifs = null;
             data = scriptsData;
           };
       "--script-opts-append" = lib.mkIf (scriptOptsData != [ ]) {
         sep = "=";
-        ifs = ",";
+        ifs = null;
         data = scriptOptsData;
       };
     }


### PR DESCRIPTION
-append accepts only single values.

fixes

https://github.com/BirdeeHub/nix-wrapper-modules/issues/518