### PR TITLE
fix(wrapperModules.fish): function abbreviations

### DIFF
--- a/wrapperModules/f/fish/module.nix
+++ b/wrapperModules/f/fish/module.nix
@@ -457,8 +457,7 @@ in
           (foldl' (
             acc: elem: acc + " " + (mkAbbrArg elem abbr)
           ) "abbr --add ${abbr.word} ${mkCursorArg abbr}" abbrArgs)
-          + " "
-          + "\"${abbr.expansion}\"";
+          + optionalString (abbr.function == null) " \"${abbr.expansion}\"";
 
         abbrs = concatStringsSep "\n" (map mkAbbrStr (attrValues cfg.abbreviations));
         aliases = concatStringsSep "\n" (


### PR DESCRIPTION
addresses https://github.com/BirdeeHub/nix-wrapper-modules/issues/519