### PR TITLE
feat(wrapperModules.television): init

### DIFF
--- a/maintainers/default.nix
+++ b/maintainers/default.nix
@@ -106,4 +106,9 @@
     github = "appleptree";
     githubId = 189892522;
   };
+  allen-liaoo = {
+    name = "Allen Liao";
+    github = "allen-liaoo";
+    githubId = 16383622;
+  };
 }

--- a/wrapperModules/t/television/module.nix
+++ b/wrapperModules/t/television/module.nix
@@ -12,7 +12,11 @@ let
     typeName = "TOML";
   };
   isPathLike =
-    x: builtins.isPath x || (builtins.isString x && lib.hasPrefix "/" x) || lib.isStorePath x;
+    x:
+    builtins.isPath x
+    || (lib.isStringLike x && !builtins.isString x)
+    || (builtins.isString x && lib.hasPrefix "/" x)
+    || lib.isStorePath x;
 in
 {
   imports = [ wlib.modules.default ];
@@ -23,7 +27,7 @@ in
       description = "Television configuration options.";
     };
     channels = lib.mkOption {
-      type = types.lazyAttrsOf (types.either types.path tomlFmtType);
+      type = types.lazyAttrsOf (types.either wlib.types.stringable tomlFmtType);
       default = { };
       description = "Television channels to install.";
     };
@@ -36,7 +40,7 @@ in
       '';
     };
     themes = lib.mkOption {
-      type = types.lazyAttrsOf (types.either types.path tomlFmtType);
+      type = types.lazyAttrsOf (types.either wlib.types.stringable tomlFmtType);
       default = { };
       description = "Themes of television to install.";
     };
@@ -58,6 +62,12 @@ in
   };
   config = {
     package = lib.mkDefault pkgs.television;
+    passthru.generatedThemesDir = "${
+      config.wrapper.${config.configDrvOutput}
+    }/${baseNameOf config.themesDir}";
+    passthru.generatedChannelsDir = "${
+      config.wrapper.${config.configDrvOutput}
+    }/${baseNameOf config.channelsDir}";
     flags = {
       "--config-file" = lib.mkIf (config.settings != { }) config.constructFiles.generatedConfig.path;
       "--cable-dir" = lib.mkIf (config.channels != { }) config.channelsDir;
@@ -76,7 +86,7 @@ in
       output = lib.mkOverride 0 config.configDrvOutput;
       ${if isPathLike v then null else "content"} = builtins.toJSON v;
       "builder" =
-        if isPathLike v then ''cp ${v} "$2"'' else ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+        if isPathLike v then ''ln -s ${v} "$2"'' else ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     }) config.channels
     // builtins.mapAttrs (n: v: {
       key = "theme_${n}";
@@ -84,7 +94,7 @@ in
       output = lib.mkOverride 0 config.configDrvOutput;
       ${if isPathLike v then null else "content"} = builtins.toJSON v;
       "builder" =
-        if isPathLike v then ''cp ${v} "$2"'' else ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+        if isPathLike v then ''ln -s ${v} "$2"'' else ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     }) config.themes;
     meta.maintainers = [ wlib.maintainers.allen-liaoo ];
   };

--- a/wrapperModules/t/television/module.nix
+++ b/wrapperModules/t/television/module.nix
@@ -1,0 +1,91 @@
+{
+  config,
+  pkgs,
+  wlib,
+  lib,
+  ...
+}:
+let
+  types = lib.types;
+  tomlFmtType = wlib.types.structuredValueWith {
+    nullable = false;
+    typeName = "TOML";
+  };
+  isPathLike =
+    x: builtins.isPath x || (builtins.isString x && lib.hasPrefix "/" x) || lib.isStorePath x;
+in
+{
+  imports = [ wlib.modules.default ];
+  options = {
+    settings = lib.mkOption {
+      type = tomlFmtType;
+      default = { };
+      description = "Television configuration options.";
+    };
+    channels = lib.mkOption {
+      type = types.lazyAttrsOf (types.either types.path tomlFmtType);
+      default = { };
+      description = "Television channels to install.";
+    };
+    channelsDir = lib.mkOption {
+      type = types.str;
+      readOnly = true;
+      default = "${placeholder config.configDrvOutput}/${config.binName}-channels";
+      description = ''
+        The placeholder for the location of the channels directory.
+      '';
+    };
+    themes = lib.mkOption {
+      type = types.lazyAttrsOf (types.either types.path tomlFmtType);
+      default = { };
+      description = "Themes of television to install.";
+    };
+    themesDir = lib.mkOption {
+      type = types.str;
+      readOnly = true;
+      default = "${placeholder config.configDrvOutput}/${config.binName}-themes";
+      description = ''
+        The placeholder for the location of the themes directory.
+      '';
+    };
+    configDrvOutput = lib.mkOption {
+      type = types.str;
+      default = config.outputName;
+      description = ''
+        The derivation output name the generated configuration will be output to.
+      '';
+    };
+  };
+  config = {
+    package = lib.mkDefault pkgs.television;
+    flags = {
+      "--config-file" = lib.mkIf (config.settings != { }) config.constructFiles.generatedConfig.path;
+      "--cable-dir" = lib.mkIf (config.channels != { }) config.channelsDir;
+    };
+    constructFiles = {
+      generatedConfig = {
+        relPath = "${config.binName}-config.toml";
+        content = builtins.toJSON config.settings;
+        builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+        output = config.configDrvOutput;
+      };
+    }
+    // builtins.mapAttrs (n: v: {
+      key = "channel_${n}";
+      relPath = lib.mkOverride 0 "${config.binName}-channels/${n}.toml";
+      output = lib.mkOverride 0 config.configDrvOutput;
+      ${if isPathLike v then null else "content"} = builtins.toJSON v;
+      "builder" =
+        if isPathLike v then ''cp ${v} "$2"'' else ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+    }) config.channels
+    // builtins.mapAttrs (n: v: {
+      key = "theme_${n}";
+      relPath = lib.mkOverride 0 "${config.binName}-themes/${n}.toml";
+      output = lib.mkOverride 0 config.configDrvOutput;
+      ${if isPathLike v then null else "content"} = builtins.toJSON v;
+      "builder" =
+        if isPathLike v then ''cp ${v} "$2"'' else ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+    }) config.themes;
+    meta.maintainers = [ wlib.maintainers.allen-liaoo ];
+  };
+}


### PR DESCRIPTION
Wrapper module for [Television](https://alexpasmantier.github.io/television/). 
Not sure what is the best/recommended way to handle TOML, so I just imitated what other wrapper modules did.