### PR TITLE
feat(wrapperModules.niri): change settings types for better merging

### DIFF
--- a/wrapperModules/n/niri/module.nix
+++ b/wrapperModules/n/niri/module.nix
@@ -144,11 +144,11 @@ in
       '';
       default = { };
       type = lib.types.submodule {
-        freeformType = lib.types.attrs;
+        freeformType = wlib.types.attrsRecursive;
         options = {
           binds = lib.mkOption {
             default = { };
-            type = lib.types.attrs;
+            type = wlib.types.attrsRecursive;
             description = "Bindings of niri";
             apply = convertAndWarn;
             example = lib.literalMD ''
@@ -168,7 +168,7 @@ in
           };
           layout = lib.mkOption {
             default = { };
-            type = lib.types.attrs;
+            type = wlib.types.attrsRecursive;
             description = "Layout definitions";
             apply = convertAndWarn;
             example = lib.literalMD ''
@@ -261,7 +261,7 @@ in
           };
           outputs = lib.mkOption {
             default = { };
-            type = lib.types.attrs;
+            type = wlib.types.attrsRecursive;
             description = "Output configuration";
             apply = convertAndWarn;
             example = lib.literalMD ''


### PR DESCRIPTION
## Issue

Currently it is not possible to merge `settings` together in the `niri` wrapper module that are part of the freeform configuration, this leads to unexpected overriding of config instead of merging config options together.

## Example

An example of an option that wouldn't merge prior to this minor change is `input`

```nix
# shared config file
wrappers.niri.settings.input.keyboard.xkb.options = "caps:escape";

# in a host file
wrappers.niri.settings.input.mouse.accel-profile = "flat";
```

The above snippet means that only one of the `input` configs is selected, there is not even an error warning that multiple options have been set.

Additionally, previously you could not set config with an override level using `mkDefault` inside nested attributes (again `input` is an example) as the `mkDefault` would be interpreted in its unwrapped attrSet.

## Other extensions

It may also be worth changing more of the defined options in the freeform settings type to use `anything` instead of `attrs` since anything correctly recursively merges attribute sets.
   - `layout`: is a good candidate as nested attribute sets can occur here
   - `binds`: it depends, it would allow partial overriding of binds set elsewhere, but this may not necessarily be wanted behaviour, and since you can't merge a `functionTo` type anyway, it appears less useful here as you may always want to set all config of a binding in one place.
   - `outputs`: for similar reasons to `binds`
   - `window-rules` and `layer-rules`: are lists of attrs, and so merging also won't happen here either so is not needed.

Just changing the toplevel to `anything` mostly solves my issues porting my `niri` config properly to `nix-wrapper-modules` from `niri-flake`.