### PR TITLE
fix(modules): use `gnused` instead of unfree `replace`

### DIFF
--- a/modules/symlinkScript/module.nix
+++ b/modules/symlinkScript/module.nix
@@ -93,7 +93,7 @@
                         # Remove symlink and create a real file with patched content
                         rm "$file"
                         # Use replace-literal which works for both text and binary files
-                        ${pkgs.replace}/bin/replace-literal "$oldPath" "$newPath" < "$target" > "$file"
+                        ${pkgs.gnused}/bin/sed "s|$oldPath|$newPath|g" "$target" > "$file"
                         # Preserve permissions
                         chmod --reference="$target" "$file"
                       fi


### PR DESCRIPTION
It is a simple, drop in replacement that fixes builds failing if `config.allowUnfree = false`

`nixos-unstable` had a recent commit [748036a](https://github.com/NixOS/nixpkgs/commit/748036a3df1a94f5f97dd15b6af0dcae24f126d6) that actually set the license, which is `unfree`. This means all wrappers that don't allow unfree packages will simply fail to build.

This fixes it by using `gnused`. I ran tests using the built in ci
```sh
check
```

And using
```sh
nix flake check -Lv ./ci
```

Both resulted in all checks passing.

I also tested by running the default template before and after. Before, it fails saying replace-2.24 requires unfree, and after is successfully builds and runs.

