### PR TITLE
ci(pages): fix permissions workaround

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -32,10 +32,8 @@ jobs:
     needs: build
     permissions:
       id-token: write
-      contents: read
+      pages: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
-        with:
-          token: ${{ secrets.PAT }}


### PR DESCRIPTION
I had a carefully scoped PAT that I needed to manually update but apparently I do not need to do that?