### PR TITLE
fix(modules.symlinkScript): replace replace with free replacement

### DIFF
--- a/modules/symlinkScript/checks/filesToPatch.nix
+++ b/modules/symlinkScript/checks/filesToPatch.nix
@@ -65,7 +65,7 @@ test "filesToPatch-test" {
                   package = pkgs.hello;
                   wrapperImplementation = "binary";
                   wrapperVariants.fileToBePatched.exePath = "bin/hello"; # <- not the main one, the outer wrapper module will thus not wrap it automatically.
-                  flags."--greeting" = "Hello, ${placeholder "out"}";
+                  flags."--greeting" = "Hello,\0 ${placeholder "out"}";
                 }
               )
             ];

--- a/modules/symlinkScript/module.nix
+++ b/modules/symlinkScript/module.nix
@@ -92,8 +92,8 @@
                         echo "Patching $file"
                         # Remove symlink and create a real file with patched content
                         rm "$file"
-                        # Use replace-literal which works for both text and binary files
-                        ${pkgs.replace}/bin/replace-literal "$oldPath" "$newPath" < "$target" > "$file"
+                        # Use gnused explicitly which works for both text and binary files
+                        ${pkgs.gnused}/bin/sed "s|$oldPath|$newPath|g" "$target" > "$file"
                         # Preserve permissions
                         chmod --reference="$target" "$file"
                       fi


### PR DESCRIPTION
pkgs.replace was marked unfree. Due to some fumbling with handling of PRs, on my part, I am going to do it, because I also updated the tests for it earlier.


https://github.com/BirdeeHub/nix-wrapper-modules/pull/525

https://github.com/BirdeeHub/nix-wrapper-modules/pull/532

Credit to @Elias-Graf and @MakeShiftArtist for this change

closes https://github.com/BirdeeHub/nix-wrapper-modules/issues/536