### PR TITLE
fix(ci.formatting): use nixfmt --check to avoid writing to read-only nix store

### DIFF
--- a/ci/checks/formatting.nix
+++ b/ci/checks/formatting.nix
@@ -5,8 +5,6 @@
 }:
 
 pkgs.runCommand "formatting-check" { } ''
-  ${
-    pkgs.lib.getExe self.formatter.${pkgs.stdenv.hostPlatform.system}
-  } --no-cache --fail-on-change ${../../.}
+  find ${../../.} -name "*.nix" -print0 | xargs -0 ${pkgs.lib.getExe pkgs.nixfmt} --check
   touch $out
 ''


### PR DESCRIPTION
## Summary

When a file needs reformatting and the formatting-check derivation is not cached, `nixfmt-tree` crashes with a cryptic `Permission denied` error instead of reporting which file needs fixing.

The root cause: nixfmt writes the reformatted output to a temp file in the same directory as the source file (for atomic in-place replacement). When the source is a read-only Nix store path, this fails. The crash only occurs when a file actually needs reformatting -- if files are already correctly formatted, nixfmt makes no writes and the check passes fine. So the bug is masked for contributors who run `nix fmt` locally before submitting.

Fix: replace the `nixfmt-tree` invocation with `nixfmt --check`, which reads files without writing anything and exits cleanly with `<file>: not formatted` for any improperly formatted files. As a bonus this produces a much more useful error message.

**Example of the unhelpful crash:**
```
nixfmt: .../wrapperModules/g/ghostty: openTempFileWithDefaultPermissions: permission denied (Permission denied)
```

**What the fix produces instead:**
```
wrapperModules/g/ghostty/module.nix: not formatted
```

The bug was first introduced in [c11bd23](https://github.com/BirdeeHub/nix-wrapper-modules/commit/c11bd23d26602fdab96c430db3b64d68118ca71c) when `nixfmt-tree` was added as the formatter. It has been masked because contributors generally run `nix fmt` locally, and the Nix derivation cache means the check only re-runs when the source tree hash changes.

Given that this is all avoided by running `nix fmt` locally, it'd make perfect sense if you'd like to stick with `nixfmt-tree` and close this PR, but I thought I should at least put the solution out there, in case anyone else found it annoying.

## Test plan

- [x] `checks.aarch64-darwin.wlib-formatting` passes on macOS CI
- [x] `checks.x86_64-linux.wlib-formatting` passes on Linux CI
- [x] Adding an unformatted `.nix` file produces a clear "not formatted" error rather than a crash