### PR TITLE
ci(tests.formatting): `find -exec {} +`

### DIFF
--- a/ci/checks/formatting.nix
+++ b/ci/checks/formatting.nix
@@ -5,6 +5,6 @@
 }:
 
 pkgs.runCommand "formatting-check" { } ''
-  find ${../../.} -name "*.nix" -print0 | xargs -0 ${pkgs.lib.getExe pkgs.nixfmt} --check
+  find ${../../.} -type f -name "*.nix" -exec ${pkgs.lib.getExe pkgs.nixfmt} --check {} +
   touch $out
 ''


### PR DESCRIPTION
find has this feature, and it also batches the files but automatically respects whatever ARG_MAX is. Lets use that instead of `find -print0 | xargs -0` in the interest of only using 1 program for gathering the args

Context: https://github.com/BirdeeHub/nix-wrapper-modules/pull/548

I forgot how find worked due to learning about the `find -print0 | xargs -0` trick for the first time

The resulting log output is the same.