### PR TITLE
docs(general): improve sidebar behaviour for docs

### DIFF
--- a/ci/docs/default.nix
+++ b/ci/docs/default.nix
@@ -93,9 +93,11 @@ in
     relPath = "${config.books.nix-wrapper-modules.generated-book-subdir}/custom.css";
     passAsContent = true;
     content = /* css */ ''
+      /* Set headings to display next to the details element dropdown */
       summary > h1, summary > h2, summary > h3 {
         display: inline;
       }
+      /* Indent module subsections (they are details elements in the module's details element) */
       details > details{
         padding-left: 20px;
       }
@@ -108,9 +110,10 @@ in
 
       (function () {
 
+        // Sets the sidebar sections open/closed status to match the open/closed state of the relevant details element
         function updateSidebarFromDetails() {
 
-            // relies on the fact that module headings are the only level 2 headings
+            // Relies on the fact that module headings are the only level 2 headings in details elements
             const closed_modules = document.querySelectorAll("details:not([open]) h2");
             const open_modules = document.querySelectorAll("details[open] h2");
             if (closed_modules.length === 0 && open_modules === 0) { return; }
@@ -135,6 +138,7 @@ in
         window.addEventListener("load", function () {
             updateSidebarFromDetails();
 
+            // Add dropdown arrows to the sidebar, using the existing functionality from mdbook's toc.js
             const foldable_sidebar = document.querySelectorAll("span:has(+ ol)");
             foldable_sidebar.forEach(header => {
               header.insertAdjacentHTML('beforeend', '<a class="chapter-fold-toggle header-toggle"><div>❱</div></a>');

--- a/ci/docs/default.nix
+++ b/ci/docs/default.nix
@@ -96,7 +96,7 @@ in
       summary > h1, summary > h2, summary > h3 {
         display: inline;
       }
-      .module-content {
+      details > details{
         padding-left: 20px;
       }
     '';
@@ -110,8 +110,9 @@ in
 
         function updateSidebarFromDetails() {
 
-            const closed_modules = document.querySelectorAll("details:not([open]) .foldable-heading");
-            const open_modules = document.querySelectorAll("details[open] .foldable-heading");
+            // relies on the fact that module headings are the only level 2 headings
+            const closed_modules = document.querySelectorAll("details:not([open]) h2");
+            const open_modules = document.querySelectorAll("details[open] h2");
             if (closed_modules.length === 0 && open_modules === 0) { return; }
 
             closed_modules.forEach(module_heading => {
@@ -125,7 +126,7 @@ in
             });
         }
 
-        const foldable_details = document.querySelectorAll("details:has(.foldable-heading)");
+        const foldable_details = document.querySelectorAll("details:has(h2)");
         foldable_details.forEach(details => {
             details.addEventListener("toggle", () => { updateSidebarFromDetails(); });
         });

--- a/ci/docs/default.nix
+++ b/ci/docs/default.nix
@@ -89,6 +89,62 @@ in
     inherit (config) warningsAreErrors;
     title = "Core (builtin) Options set";
   } "core" { };
+  config.constructFiles."custom.css" = {
+    relPath = "${config.books.nix-wrapper-modules.generated-book-subdir}/custom.css";
+    passAsContent = true;
+    content = /* css */ ''
+      summary > h1, summary > h2, summary > h3 {
+        display: inline;
+      }
+      .module-content {
+        padding-left: 20px;
+      }
+    '';
+  };
+  config.constructFiles."sidebar_fold.js" = {
+    relPath = "${config.books.nix-wrapper-modules.generated-book-subdir}/sidebar_fold.js";
+    passAsContent = true;
+    content = /* js */ ''
+
+      (function () {
+
+        function updateSidebarFromDetails() {
+
+            const closed_modules = document.querySelectorAll("details:not([open]) .foldable-heading");
+            const open_modules = document.querySelectorAll("details[open] .foldable-heading");
+            if (closed_modules.length === 0 && open_modules === 0) { return; }
+
+            closed_modules.forEach(module_heading => {
+                const module_sidebar = document.querySelector(`a[href='#''${module_heading.id}']`);
+                module_sidebar.closest("li").classList.remove("expanded");
+            });
+
+            open_modules.forEach(module_heading => {
+                const module_sidebar = document.querySelector(`a[href='#''${module_heading.id}']`);
+                module_sidebar.closest("li").classList.add("expanded");
+            });
+        }
+
+        const foldable_details = document.querySelectorAll("details:has(.foldable-heading)");
+        foldable_details.forEach(details => {
+            details.addEventListener("toggle", () => { updateSidebarFromDetails(); });
+        });
+
+        // mdbook js loads toc elements on DOMContentLoaded so we have to use window 'load' here
+        window.addEventListener("load", function () {
+            updateSidebarFromDetails();
+
+            const foldable_sidebar = document.querySelectorAll("span:has(+ ol)");
+            foldable_sidebar.forEach(header => {
+              header.insertAdjacentHTML('beforeend', '<a class="chapter-fold-toggle header-toggle"><div>❱</div></a>');
+              header.querySelector("a.header-toggle").addEventListener("click", () => {
+                header.closest("li").classList.toggle("expanded");
+                });
+            });
+        });
+      })();
+    '';
+  };
   config.books.nix-wrapper-modules = {
     book = {
       book = {
@@ -98,7 +154,11 @@ in
         title = "nix-wrapper-modules";
         description = "Make wrapper derivations with the module system! Use the existing modules, or write your own!";
       };
-      output.html.git-repository-url = "https://github.com/BirdeeHub/nix-wrapper-modules";
+      output.html = {
+        git-repository-url = "https://github.com/BirdeeHub/nix-wrapper-modules";
+        additional-css = [ "custom.css" ];
+        additional-js = [ "sidebar_fold.js" ];
+      };
     };
     summary = [
       {

--- a/ci/docs/per-mod/rendermd.nix
+++ b/ci/docs/per-mod/rendermd.nix
@@ -80,7 +80,7 @@ let
         (v: v)
     )
       ''
-        ## `${lib.options.showOption (opt.loc or [ ])}`
+        ### `${lib.options.showOption (opt.loc or [ ])}`
 
         ${mkOptField opt "description" ""}${mkOptField opt "relatedPackages" "Related packages:\n"}${
           mkOptField opt "type" "Type:${lib.optionalString (opt.readOnly or false == true) " (read-only)"}"
@@ -105,11 +105,19 @@ let
       moduleNotes = extraModuleNotes i mod;
     in
     lib.optionalString (mod.visible or [ ] != [ ]) ''
-      ## ${nameFromModule mod}
+      <details${if moduleStartsOpen i mod then " open" else ""}>
+      <summary markdown="block">
+
+      ## ${nameFromModule mod} {.foldable-heading}
+
+      </summary>
+      <div class="module-content">
+
       ${lib.optionalString (builtins.isString moduleNotes && moduleNotes != "") "\n${moduleNotes}\n"}
       ${lib.optionalString (mod.description.pre or "" != "" && descriptionIncluded "pre" i mod) ''
-        <details${if descriptionStartsOpen "pre" i mod then " open" else ""}>
-          <summary></summary>
+        <details${if descriptionStartsOpen "pre" i mod then " open" else ""} markdown="1">
+        <summary><h3>Pre</h3></summary>
+
 
         ${mod.description.pre}
 
@@ -118,7 +126,7 @@ let
       ''}
       ${lib.optionalString (mod.visible or [ ] != [ ]) ''
         <details${if moduleStartsOpen i mod then " open" else ""}>
-          <summary></summary>
+          <summary><h3>Options</h3></summary>
 
         ${lib.pipe mod.visible [
           (map renderOption)
@@ -130,12 +138,14 @@ let
       ${lib.optionalString (mod.description.post or "" != "" && descriptionIncluded "post" i mod) ''
 
         <details${if descriptionStartsOpen "post" i mod then " open" else ""}>
-          <summary></summary>
+          <summary><h3>Post</h3></summary>
 
         ${mod.description.post}
 
         </details>
       ''}
+      </div>
+      </details>
     '';
 in
 builtins.unsafeDiscardStringContext (

--- a/ci/docs/per-mod/rendermd.nix
+++ b/ci/docs/per-mod/rendermd.nix
@@ -106,17 +106,20 @@ let
     in
     lib.optionalString (mod.visible or [ ] != [ ]) ''
       <details${if moduleStartsOpen i mod then " open" else ""}>
-      <summary markdown="block">
+      <summary>
 
-      ## ${nameFromModule mod} {.foldable-heading}
+      ## ${nameFromModule mod}
 
       </summary>
-      <div class="module-content">
 
       ${lib.optionalString (builtins.isString moduleNotes && moduleNotes != "") "\n${moduleNotes}\n"}
       ${lib.optionalString (mod.description.pre or "" != "" && descriptionIncluded "pre" i mod) ''
-        <details${if descriptionStartsOpen "pre" i mod then " open" else ""} markdown="1">
-        <summary><h3>Pre</h3></summary>
+        <details${if descriptionStartsOpen "pre" i mod then " open" else ""}>
+        <summary>
+
+        ### Overview
+
+        </summary>
 
 
         ${mod.description.pre}
@@ -126,7 +129,11 @@ let
       ''}
       ${lib.optionalString (mod.visible or [ ] != [ ]) ''
         <details${if moduleStartsOpen i mod then " open" else ""}>
-          <summary><h3>Options</h3></summary>
+          <summary>
+
+          ### Options
+
+          </summary>
 
         ${lib.pipe mod.visible [
           (map renderOption)
@@ -138,13 +145,16 @@ let
       ${lib.optionalString (mod.description.post or "" != "" && descriptionIncluded "post" i mod) ''
 
         <details${if descriptionStartsOpen "post" i mod then " open" else ""}>
-          <summary><h3>Post</h3></summary>
+          <summary>
+
+          ### Notes
+
+          </summary>
 
         ${mod.description.post}
 
         </details>
       ''}
-      </div>
       </details>
     '';
 in


### PR DESCRIPTION
This is not final, I wanted to get your thoughts on how it is progressing.

## Changes
- On load, sidebar sections which are closed on the page are closed on the side bar
- When sections on the page are opened/closed the sidebar is updated
- Added collapse buttons to sidebar sections
- Moved headings to lineup with the details dropdown arrow on the page and nested subsection collapsible under module collapsible 

## Notes:
- A lot of the sidebar functionality should be happening already, but there seems to be a bug in the toc.js which is distributed by mdbook. I tried to find how/where this is generated, but haven't had any luck yet. In the long term, it may be cleaner to fix the issues by overriding/submitting a bug fix for this file. (see below for bug)
- The changes seem to break the way mdbook highlights the current heading in the sidebar. I need to investigate why.
- The changes to the details sections on the pages themselves are what I think looks better. The subsection names ("pre", "options", "post") are just placeholders for text we can choose if you like the idea.

### Bug
At line 409 in toc.js, the add the expanded class, ignoring the foldLevel constant check.
```js
li.classList.add('expanded');
if (level < foldLevel) {
    li.classList.add('expanded');
}
```