### PR TITLE
feat(wrapperModules.iamb): init

### DIFF
--- a/maintainers/default.nix
+++ b/maintainers/default.nix
@@ -111,4 +111,9 @@
     github = "allen-liaoo";
     githubId = 16383622;
   };
+  aliaslion = {
+    name = "aliaslion";
+    github = "aliaslion";
+    githubId = "122117018";
+  };
 }

--- a/wrapperModules/i/iamb/module.nix
+++ b/wrapperModules/i/iamb/module.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  wlib,
+  pkgs,
+  ...
+}:
+{
+  imports = [ wlib.modules.default ];
+  options = {
+    settings = lib.mkOption {
+      type = wlib.types.structuredValueWith {
+        nullable = false;
+        typeName = "TOML";
+      };
+      default = { };
+      description = ''
+        Configuration of iamb.
+        See {manpage}`iamb(5)` or <https://iamb.chat/configure.html>
+
+        Note: at least one profile is required for startup.
+      '';
+      example.profiles.myuser.user_id = "@user:example.com";
+    };
+  };
+  config.package = lib.mkDefault pkgs.iamb;
+  config.flags."--config-directory" = dirOf (dirOf config.constructFiles.config.path);
+  config.passthru.generatedConfig = dirOf (dirOf config.constructFiles.config.outPath);
+  config.constructFiles.config = {
+    relPath = "${config.binName}-config/iamb/config.toml";
+    content = builtins.toJSON config.settings;
+    builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+  };
+  config.meta.maintainers = [ wlib.maintainers.aliaslion ];
+}


### PR DESCRIPTION
Adds wrapper module for iamb, a TUI Matrix client with vi-like keybinds.

Note that I'm not completely sure what `generatedConfig.output` and `.placeholder` do, I cobbled this together from the Alacritty and Yazi modules. Would appreciate some info about that :)