### PR TITLE
feat(wrapperModules.quickshell): add 'configDir' option

### DIFF
--- a/wrapperModules/q/quickshell/module.nix
+++ b/wrapperModules/q/quickshell/module.nix
@@ -27,7 +27,15 @@ in
         The quickshell shell.qml configuration file.
 
         Provide either inlined configuration or reference an external file.
-        It is used by quickshell using `--path`.
+      '';
+    };
+    configDir = mkOption {
+      type = wlib.types.linkable;
+      default = config.generated.placeholder;
+      description = ''
+        The full quickshell configuration directory.
+
+        It is passed to quickshell using `--path`.
       '';
     };
     components = mkOption {
@@ -49,7 +57,7 @@ in
   };
 
   config.package = mkDefault pkgs.quickshell;
-  config.flags."--path" = config.generated.placeholder;
+  config.flags."--path" = config.configDir;
 
   config.passthru.generatedConfigDir = "${
     config.wrapper.${config.generated.output}


### PR DESCRIPTION
Problem:
The current implementation only allows to link single component files next to the shell.qml file. This makes it impossible to use nested quickshell components and import them via `import qs.xxx.xxx`

First solution:
remove the auto capitalization of the component names to allow for passing a directory of components or a nested path of components. However because all the files were generated into different /nix/store paths as the shell.qml file using root imports was impossible because these files were not in the same directory.

Solution:
Add `configDir` option alongside `configFile`, which if set symlinks the whole directory to the `quickshell-config` path