### PR TITLE
fix(wrapperModules.git): allow duplicate settings keys

### DIFF
--- a/wrapperModules/g/git/check.nix
+++ b/wrapperModules/g/git/check.nix
@@ -12,6 +12,10 @@ let
         name = "Test User";
         email = "test@example.com";
       };
+      credential.helper = [
+        "git-credential-libsecret"
+        "!gh auth git-credential"
+      ];
     };
   };
 
@@ -19,5 +23,7 @@ in
 pkgs.runCommand "git-test" { } ''
   "${gitWrapped}/bin/git" config user.name | grep -q "Test User"
   "${gitWrapped}/bin/git" config user.email | grep -q "test@example.com"
+  "${gitWrapped}/bin/git" config get --all credential.helper | grep -q "git-credential-libsecret"
+  "${gitWrapped}/bin/git" config credential.helper | grep -q "!gh auth git-credential"
   touch $out
 ''

--- a/wrapperModules/g/git/module.nix
+++ b/wrapperModules/g/git/module.nix
@@ -9,7 +9,7 @@
   imports = [ wlib.modules.default ];
   options = {
     settings = lib.mkOption {
-      inherit (pkgs.formats.gitIni { }) type;
+      inherit (pkgs.formats.gitIni { listsAsDuplicateKeys = true; }) type;
       default = { };
       description = ''
         Git configuration settings.


### PR DESCRIPTION
For example, multiple instances of the credential.helper option are allowed to define multiple credential helpers.