### PR TITLE
docs(wrapperModules.nushell): add notes about the differences to normal config file placement

### DIFF
--- a/wrapperModules/n/nushell/module.nix
+++ b/wrapperModules/n/nushell/module.nix
@@ -19,6 +19,11 @@
         Provide either `.content` to inline the file contents or `.path` to reference an existing file.
         This file is passed to Nushell using `--env-config`, and is typically used to define
         environment variables or startup commands that apply to all shells.
+
+        Note that Nushell also reads this file in non-interactive environments unless
+        `--no-config-file` is specified. This is a subtle yet significant difference from
+        placing the config file at $XDG_CONFIG_HOME/nushell/env.nu. For more details, see
+        https://www.nushell.sh/book/configuration.html#flag-behavior.
       '';
     };
     "config.nu" = lib.mkOption {
@@ -32,6 +37,11 @@
         Provide either `.content` to inline the file contents or `.path` to reference an existing file.
         This file is passed to Nushell using `--config`, and controls general shell behavior,
         key bindings, and built-in command settings.
+
+        Note that Nushell also reads this file in non-interactive environments unless
+        `--no-config-file` is specified. This is a subtle yet significant difference from
+        placing the config file at $XDG_CONFIG_HOME/nushell/config.nu. For more details, see
+        https://www.nushell.sh/book/configuration.html#flag-behavior.
       '';
     };
   };


### PR DESCRIPTION
See https://www.nushell.sh/book/configuration.html#flag-behavior.

<details>
<summary>Outdated summary</summary>
The problem with setting the `--config` flag is that the configuration is loaded even in non-interactive environments. See https://www.nushell.sh/book/configuration.html#scenarios.

Note that this is a breaking change since it changes `$nu.default-config-dir` and affects the location of the history file, which has to be set to a non-Nix store location using `$env.config.history.path`. If you feel like this trade-off isn't worthwhile or have any suggestions, please suggest them or close this PR.
</details>