### PR TITLE
feat(wrapperModules.zed): init

### DIFF
--- a/maintainers/default.nix
+++ b/maintainers/default.nix
@@ -116,4 +116,10 @@
     github = "aliaslion";
     githubId = "122117018";
   };
+  sibaldh = {
+    name = "Sibald Hulselmans";
+    email = "sibald.hulselmans@protonmail.com";
+    github = "sibaldh";
+    githubId = "94047298";
+  };
 }

--- a/wrapperModules/z/zed/check.nix
+++ b/wrapperModules/z/zed/check.nix
@@ -1,0 +1,94 @@
+{
+  pkgs,
+  self,
+  tlib,
+  ...
+}:
+
+let
+  inherit (tlib)
+    fileContains
+    isDirectory
+    isFile
+    test
+    ;
+
+  wrapper = self.wrappers.zed.wrap {
+    inherit pkgs;
+
+    userSettings = {
+      vim_mode = true;
+      telemetry.metrics = false;
+    };
+
+    userKeymaps = [
+      {
+        context = "Workspace";
+        bindings = {
+          ctrl-shift-t = "workspace::NewTerminal";
+        };
+      }
+    ];
+
+    userTasks = [
+      {
+        label = "nix flake check";
+        command = "nix";
+        args = [
+          "flake"
+          "check"
+        ];
+      }
+    ];
+
+    userDebug = [
+      {
+        label = "Example";
+        adapter = "CodeLLDB";
+        request = "launch";
+        program = "$ZED_FILE";
+      }
+    ];
+
+    extensions = [ "nix" ];
+
+    themes.example = {
+      name = "Example";
+      author = "nix-wrapper-modules";
+      themes = [ ];
+    };
+  };
+
+in
+test { wrapper = "zed"; } {
+  "zed wrapper should be created" = [
+    (isDirectory wrapper)
+    (isFile "${wrapper}/bin/zeditor")
+  ];
+
+  "zed settings should be generated" = [
+    (isFile "${wrapper.generatedConfig}/zed/settings.json")
+    (fileContains "${wrapper.generatedConfig}/zed/settings.json" "vim_mode")
+    (fileContains "${wrapper.generatedConfig}/zed/settings.json" "auto_install_extensions")
+  ];
+
+  "zed keymaps should be generated" = [
+    (isFile "${wrapper.generatedConfig}/zed/keymap.json")
+    (fileContains "${wrapper.generatedConfig}/zed/keymap.json" "workspace::NewTerminal")
+  ];
+
+  "zed tasks should be generated" = [
+    (isFile "${wrapper.generatedConfig}/zed/tasks.json")
+    (fileContains "${wrapper.generatedConfig}/zed/tasks.json" "nix flake check")
+  ];
+
+  "zed debug config should be generated" = [
+    (isFile "${wrapper.generatedConfig}/zed/debug.json")
+    (fileContains "${wrapper.generatedConfig}/zed/debug.json" "CodeLLDB")
+  ];
+
+  "zed themes should be generated" = [
+    (isFile "${wrapper.generatedConfig}/zed/themes/example.json")
+    (fileContains "${wrapper.generatedConfig}/zed/themes/example.json" "Example")
+  ];
+}

--- a/wrapperModules/z/zed/module.nix
+++ b/wrapperModules/z/zed/module.nix
@@ -1,0 +1,357 @@
+{
+  config,
+  lib,
+  wlib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkOption
+    optionalAttrs
+    optionalString
+    types
+    ;
+
+  jsonFormat = pkgs.formats.json { };
+  json5 = pkgs.python3Packages.toPythonApplication pkgs.python3Packages.json5;
+
+  isPathLike = value: builtins.isPath value || lib.isStorePath value;
+
+  generatedSettings =
+    config.userSettings
+    // optionalAttrs (config.extensions != [ ]) {
+      auto_install_extensions = lib.genAttrs config.extensions (_: true);
+    };
+
+  pathThemes = lib.filterAttrs (_name: value: isPathLike value) config.themes;
+
+  generatedThemes = lib.filterAttrs (_name: value: !(isPathLike value)) config.themes;
+
+  hasGeneratedConfig =
+    generatedSettings != { }
+    || config.userKeymaps != [ ]
+    || config.userTasks != [ ]
+    || config.userDebug != [ ]
+    || config.themes != { };
+
+  zedConfigDir = "${config.generatedConfig.placeholder}/zed";
+
+  mkJsonFile = relPath: value: {
+    inherit relPath;
+    content = builtins.toJSON value;
+  };
+
+  mkThemeFile = name: value: {
+    relPath = "${config.generatedConfig.relPath}/zed/themes/${name}.json";
+    content = if builtins.isString value then value else builtins.toJSON value;
+  };
+
+in
+{
+  imports = [ wlib.modules.default ];
+
+  options = {
+    userSettings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        vim_mode = true;
+        telemetry = {
+          diagnostics = false;
+          metrics = false;
+        };
+        ui_font_family = "JetBrainsMono Nerd Font";
+        buffer_font_family = "JetBrainsMono Nerd Font";
+      };
+      description = ''
+        Configuration written to Zed's `settings.json`.
+
+        This is equivalent to Home Manager's
+        `programs.zed-editor.userSettings` option.
+      '';
+    };
+
+    userKeymaps = mkOption {
+      inherit (jsonFormat) type;
+      default = [ ];
+      example = [
+        {
+          context = "Workspace";
+          bindings = {
+            ctrl-shift-t = "workspace::NewTerminal";
+          };
+        }
+      ];
+      description = ''
+        Configuration written to Zed's `keymap.json`.
+
+        This is equivalent to Home Manager's
+        `programs.zed-editor.userKeymaps` option.
+      '';
+    };
+
+    userTasks = mkOption {
+      inherit (jsonFormat) type;
+      default = [ ];
+      example = [
+        {
+          label = "Format Code";
+          command = "nix";
+          args = [
+            "fmt"
+            "$ZED_WORKTREE_ROOT"
+          ];
+        }
+      ];
+      description = ''
+        Configuration written to Zed's `tasks.json`.
+
+        These are global Zed tasks that can be run from the command palette.
+      '';
+    };
+
+    userDebug = mkOption {
+      inherit (jsonFormat) type;
+      default = [ ];
+      example = [
+        {
+          label = "Go (Delve)";
+          adapter = "Delve";
+          program = "$ZED_FILE";
+          request = "launch";
+          mode = "debug";
+        }
+      ];
+      description = ''
+        Configuration written to Zed's `debug.json`.
+
+        These are global debug configurations for Zed's debugger.
+      '';
+    };
+
+    extensions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "nix"
+        "toml"
+      ];
+      description = ''
+        A list of Zed extensions to install on startup.
+
+        The values are translated into the `auto_install_extensions`
+        setting in `settings.json`.
+      '';
+    };
+
+    themes = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          jsonFormat.type
+          types.path
+          types.lines
+        ]
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          my-theme = {
+            name = "My Theme";
+            author = "Me";
+            themes = [ ];
+          };
+        }
+      '';
+      description = ''
+        Themes written to `zed/themes/<name>.json`.
+
+        Attribute names become theme file names.
+      '';
+    };
+
+    configMode = mkOption {
+      type = types.enum [
+        "copy"
+        "xdgConfigHome"
+        "none"
+      ];
+      default = "copy";
+      description = ''
+        How the generated Zed configuration should be made visible to Zed.
+
+        - `copy`: copy or merge generated files into the user's real
+          `$XDG_CONFIG_HOME/zed` directory when Zed starts. This keeps Zed
+          mutable and avoids leaking a custom `XDG_CONFIG_HOME` into terminals,
+          tasks, and language servers spawned by Zed.
+        - `xdgConfigHome`: set `XDG_CONFIG_HOME` to the generated immutable
+          config directory in the wrapper derivation.
+        - `none`: only expose the generated config through
+          `passthru.generatedConfig`; do not apply it automatically.
+      '';
+    };
+
+    generatedConfig = {
+      output = mkOption {
+        type = types.str;
+        default = config.outputName;
+        description = ''
+          The derivation output where the generated Zed configuration is placed.
+        '';
+      };
+
+      relPath = mkOption {
+        type = types.str;
+        default = "${config.binName}-config";
+        description = ''
+          Relative path inside the wrapper derivation where generated Zed
+          configuration files are placed.
+        '';
+      };
+
+      placeholder = mkOption {
+        type = types.str;
+        default = "${placeholder config.generatedConfig.output}/${config.generatedConfig.relPath}";
+        readOnly = true;
+        description = ''
+          Placeholder path to the generated Zed configuration, available inside
+          the wrapper derivation build script.
+        '';
+      };
+    };
+  };
+
+  config = {
+    binName = mkDefault "zeditor";
+    package = mkDefault pkgs.zed-editor;
+
+    meta = {
+      description = ''
+        Wraps Zed with declarative settings, keymaps, tasks, debug
+        configurations, themes, extensions, and runtime PATH additions.
+      '';
+
+      maintainers = [
+        wlib.maintainers.sibaldh
+      ];
+    };
+
+    constructFiles =
+      optionalAttrs (generatedSettings != { }) {
+        zedSettings = mkJsonFile "${config.generatedConfig.relPath}/zed/settings.json" generatedSettings;
+      }
+      // optionalAttrs (config.userKeymaps != [ ]) {
+        zedKeymaps = mkJsonFile "${config.generatedConfig.relPath}/zed/keymap.json" config.userKeymaps;
+      }
+      // optionalAttrs (config.userTasks != [ ]) {
+        zedTasks = mkJsonFile "${config.generatedConfig.relPath}/zed/tasks.json" config.userTasks;
+      }
+      // optionalAttrs (config.userDebug != [ ]) {
+        zedDebug = mkJsonFile "${config.generatedConfig.relPath}/zed/debug.json" config.userDebug;
+      }
+      // lib.mapAttrs' (
+        name: value: lib.nameValuePair "zedTheme-${name}" (mkThemeFile name value)
+      ) generatedThemes;
+
+    buildCommand.zedPathThemes = mkIf (pathThemes != { }) {
+      before = [
+        "constructFiles"
+        "makeWrapper"
+      ];
+
+      data = ''
+        mkdir -p ${lib.escapeShellArg "${zedConfigDir}/themes"}
+      ''
+      + lib.concatMapAttrsStringSep "\n" (name: value: ''
+        ln -sfn ${lib.escapeShellArg value} ${lib.escapeShellArg "${zedConfigDir}/themes/${name}.json"}
+      '') pathThemes;
+    };
+
+    runShell = mkIf (hasGeneratedConfig && config.configMode == "copy") [
+      {
+        name = "NIX_ZED_SYNC_CONFIG";
+        "esc-fn" = wlib.escapeShellArgWithEnv;
+
+        data = ''
+          nix_zed_config=${zedConfigDir}
+          user_zed_config="''${XDG_CONFIG_HOME:-$HOME/.config}/zed"
+
+          merge_json_file() {
+            empty="$1"
+            jq_operation="$2"
+            target="$3"
+            static="$4"
+
+            mkdir -p "$(dirname "$target")"
+
+            if [ ! -e "$target" ]; then
+              printf '%s\n' "$empty" > "$target"
+            fi
+
+            dynamic="$(${lib.getExe json5} --as-json "$target" 2>/dev/null || printf '%s\n' "$empty")"
+            static_content="$(cat "$static")"
+
+            ${lib.getExe pkgs.jq} \
+              -n "$jq_operation" \
+              --argjson dynamic "$dynamic" \
+              --argjson static "$static_content" \
+              > "$target.tmp"
+
+            mv "$target.tmp" "$target"
+          }
+
+          ${optionalString (generatedSettings != { }) ''
+            merge_json_file \
+              '{}' \
+              '$dynamic * $static' \
+              "$user_zed_config/settings.json" \
+              "$nix_zed_config/settings.json"
+          ''}
+
+          ${optionalString (config.userKeymaps != [ ]) ''
+            merge_json_file \
+              '[]' \
+              '$dynamic + $static | group_by(.context) | map(reduce .[] as $item ({}; . * $item))' \
+              "$user_zed_config/keymap.json" \
+              "$nix_zed_config/keymap.json"
+          ''}
+
+          ${optionalString (config.userTasks != [ ]) ''
+            merge_json_file \
+              '[]' \
+              '$dynamic + $static | group_by(.label) | map(reduce .[] as $item ({}; . * $item))' \
+              "$user_zed_config/tasks.json" \
+              "$nix_zed_config/tasks.json"
+          ''}
+
+          ${optionalString (config.userDebug != [ ]) ''
+            merge_json_file \
+              '[]' \
+              '$dynamic + $static | group_by(.label) | map(reduce .[] as $item ({}; . * $item))' \
+              "$user_zed_config/debug.json" \
+              "$nix_zed_config/debug.json"
+          ''}
+
+          if [ -d "$nix_zed_config/themes" ]; then
+            mkdir -p "$user_zed_config/themes"
+            for theme in "$nix_zed_config/themes/"*.json; do
+              [ -e "$theme" ] || continue
+              cp -f "$theme" "$user_zed_config/themes/$(basename "$theme")"
+            done
+          fi
+        '';
+      }
+    ];
+
+    env = mkIf (hasGeneratedConfig && config.configMode == "xdgConfigHome") {
+      XDG_CONFIG_HOME = config.generatedConfig.placeholder;
+    };
+
+    passthru.generatedConfig = "${
+      config.wrapper.${config.generatedConfig.output}
+    }/${config.generatedConfig.relPath}";
+  };
+}

--- a/wrapperModules/z/zed/module.nix
+++ b/wrapperModules/z/zed/module.nix
@@ -18,8 +18,7 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  isPathLike = value:
-    builtins.isPath value || lib.isStorePath value;
+  isPathLike = value: builtins.isPath value || lib.isStorePath value;
 
   generatedSettings =
     config.userSettings
@@ -27,11 +26,9 @@ let
       auto_install_extensions = lib.genAttrs config.extensions (_: true);
     };
 
-  pathThemes =
-    lib.filterAttrs (_name: value: isPathLike value) config.themes;
+  pathThemes = lib.filterAttrs (_name: value: isPathLike value) config.themes;
 
-  generatedThemes =
-    lib.filterAttrs (_name: value: !(isPathLike value)) config.themes;
+  generatedThemes = lib.filterAttrs (_name: value: !(isPathLike value)) config.themes;
 
   hasGeneratedConfig =
     generatedSettings != { }
@@ -40,8 +37,7 @@ let
     || config.userDebug != [ ]
     || config.themes != { };
 
-  generatedZedConfigDir =
-    "${config.generatedConfig.path}/zed";
+  generatedZedConfigDir = "${config.generatedConfig.path}/zed";
 
   mkJsonFile = relPath: value: {
     inherit relPath;
@@ -50,11 +46,7 @@ let
 
   mkThemeFile = name: value: {
     relPath = "${config.generatedConfig.relPath}/zed/themes/${name}.json";
-    content =
-      if builtins.isString value then
-        value
-      else
-        builtins.toJSON value;
+    content = if builtins.isString value then value else builtins.toJSON value;
   };
 
 in
@@ -251,34 +243,25 @@ in
       '';
 
       maintainers = [
-        wlib.maintainers.YOUR_HANDLE
+        wlib.maintainers.sibaldh
       ];
     };
 
     constructFiles =
       optionalAttrs (generatedSettings != { }) {
-        zedSettings = mkJsonFile
-          "${config.generatedConfig.relPath}/zed/settings.json"
-          generatedSettings;
+        zedSettings = mkJsonFile "${config.generatedConfig.relPath}/zed/settings.json" generatedSettings;
       }
       // optionalAttrs (config.userKeymaps != [ ]) {
-        zedKeymaps = mkJsonFile
-          "${config.generatedConfig.relPath}/zed/keymap.json"
-          config.userKeymaps;
+        zedKeymaps = mkJsonFile "${config.generatedConfig.relPath}/zed/keymap.json" config.userKeymaps;
       }
       // optionalAttrs (config.userTasks != [ ]) {
-        zedTasks = mkJsonFile
-          "${config.generatedConfig.relPath}/zed/tasks.json"
-          config.userTasks;
+        zedTasks = mkJsonFile "${config.generatedConfig.relPath}/zed/tasks.json" config.userTasks;
       }
       // optionalAttrs (config.userDebug != [ ]) {
-        zedDebug = mkJsonFile
-          "${config.generatedConfig.relPath}/zed/debug.json"
-          config.userDebug;
+        zedDebug = mkJsonFile "${config.generatedConfig.relPath}/zed/debug.json" config.userDebug;
       }
       // lib.mapAttrs' (
-        name: value:
-        lib.nameValuePair "zedTheme-${name}" (mkThemeFile name value)
+        name: value: lib.nameValuePair "zedTheme-${name}" (mkThemeFile name value)
       ) generatedThemes;
 
     buildCommand.zedPathThemes = mkIf (pathThemes != { }) {
@@ -288,16 +271,12 @@ in
         "symlinkScript"
       ];
 
-      data =
-        ''
-          mkdir -p ${lib.escapeShellArg "${generatedZedConfigDir}/themes"}
-        ''
-        + lib.concatMapAttrsStringSep "\n" (
-          name: value:
-          ''
-            ln -sfn ${lib.escapeShellArg value} ${lib.escapeShellArg "${generatedZedConfigDir}/themes/${name}.json"}
-          ''
-        ) pathThemes;
+      data = ''
+        mkdir -p ${lib.escapeShellArg "${generatedZedConfigDir}/themes"}
+      ''
+      + lib.concatMapAttrsStringSep "\n" (name: value: ''
+        ln -sfn ${lib.escapeShellArg value} ${lib.escapeShellArg "${generatedZedConfigDir}/themes/${name}.json"}
+      '') pathThemes;
     };
 
     runShell = mkIf (hasGeneratedConfig && config.linkConfig) [

--- a/wrapperModules/z/zed/module.nix
+++ b/wrapperModules/z/zed/module.nix
@@ -1,0 +1,359 @@
+{
+  config,
+  lib,
+  wlib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    optionalAttrs
+    types
+    ;
+
+  jsonFormat = pkgs.formats.json { };
+
+  isPathLike = value:
+    builtins.isPath value || lib.isStorePath value;
+
+  generatedSettings =
+    config.userSettings
+    // optionalAttrs (config.extensions != [ ]) {
+      auto_install_extensions = lib.genAttrs config.extensions (_: true);
+    };
+
+  pathThemes =
+    lib.filterAttrs (_name: value: isPathLike value) config.themes;
+
+  generatedThemes =
+    lib.filterAttrs (_name: value: !(isPathLike value)) config.themes;
+
+  hasGeneratedConfig =
+    generatedSettings != { }
+    || config.userKeymaps != [ ]
+    || config.userTasks != [ ]
+    || config.userDebug != [ ]
+    || config.themes != { };
+
+  generatedZedConfigDir =
+    "${config.generatedConfig.path}/zed";
+
+  mkJsonFile = relPath: value: {
+    inherit relPath;
+    content = builtins.toJSON value;
+  };
+
+  mkThemeFile = name: value: {
+    relPath = "${config.generatedConfig.relPath}/zed/themes/${name}.json";
+    content =
+      if builtins.isString value then
+        value
+      else
+        builtins.toJSON value;
+  };
+
+in
+{
+  imports = [ wlib.modules.default ];
+
+  options = {
+    userSettings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        vim_mode = true;
+        telemetry = {
+          diagnostics = false;
+          metrics = false;
+        };
+        ui_font_family = "JetBrainsMono Nerd Font";
+        buffer_font_family = "JetBrainsMono Nerd Font";
+      };
+      description = ''
+        Configuration written to Zed's `settings.json`.
+
+        This is equivalent to Home Manager's
+        `programs.zed-editor.userSettings` option.
+      '';
+    };
+
+    userKeymaps = mkOption {
+      inherit (jsonFormat) type;
+      default = [ ];
+      example = [
+        {
+          context = "Workspace";
+          bindings = {
+            ctrl-shift-t = "workspace::NewTerminal";
+          };
+        }
+      ];
+      description = ''
+        Configuration written to Zed's `keymap.json`.
+
+        This is equivalent to Home Manager's
+        `programs.zed-editor.userKeymaps` option.
+      '';
+    };
+
+    userTasks = mkOption {
+      inherit (jsonFormat) type;
+      default = [ ];
+      example = [
+        {
+          label = "nix flake check";
+          command = "nix";
+          args = [
+            "flake"
+            "check"
+          ];
+        }
+      ];
+      description = ''
+        Configuration written to Zed's `tasks.json`.
+
+        These are global Zed tasks that can be run from the command palette.
+      '';
+    };
+
+    userDebug = mkOption {
+      inherit (jsonFormat) type;
+      default = [ ];
+      example = [
+        {
+          label = "Example";
+          adapter = "CodeLLDB";
+          request = "launch";
+          program = "$ZED_FILE";
+        }
+      ];
+      description = ''
+        Configuration written to Zed's `debug.json`.
+
+        These are global debug configurations for Zed's debugger.
+      '';
+    };
+
+    extensions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "nix"
+        "toml"
+      ];
+      description = ''
+        A list of Zed extensions to install on startup.
+
+        The values are translated into the `auto_install_extensions`
+        setting in `settings.json`.
+      '';
+    };
+
+    themes = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          jsonFormat.type
+          types.path
+          types.lines
+        ]
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          my-theme = {
+            name = "My Theme";
+            author = "Me";
+            themes = [ ];
+          };
+        }
+      '';
+      description = ''
+        Themes written to `zed/themes/<name>.json`.
+
+        Attribute names become theme file names.
+
+        Values may be JSON-like Nix values, raw JSON strings, or paths to
+        existing theme files.
+      '';
+    };
+
+    linkConfig = mkEnableOption ''
+      symlinking generated Zed configuration into `$XDG_CONFIG_HOME/zed`
+      before launching Zed
+    '';
+
+    forceSymlinks = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to replace existing files or symlinks in `$XDG_CONFIG_HOME/zed`
+        when linking generated Zed configuration.
+
+        If disabled, the wrapper refuses to overwrite existing files that are
+        not already the expected symlink.
+      '';
+    };
+
+    generatedConfig = {
+      output = mkOption {
+        type = types.str;
+        default = config.outputName;
+        description = ''
+          The derivation output where the generated Zed configuration is placed.
+        '';
+      };
+
+      relPath = mkOption {
+        type = types.str;
+        default = "${config.binName}-config";
+        description = ''
+          Relative path inside the wrapper derivation where generated Zed
+          configuration files are placed.
+        '';
+      };
+
+      path = mkOption {
+        type = types.str;
+        default = "${placeholder config.generatedConfig.output}/${config.generatedConfig.relPath}";
+        readOnly = true;
+        description = ''
+          Placeholder path to the generated Zed configuration, available inside
+          the wrapper derivation build script.
+        '';
+      };
+
+      outPath = mkOption {
+        type = types.str;
+        default = "${config.wrapper.${config.generatedConfig.output}}/${config.generatedConfig.relPath}";
+        readOnly = true;
+        description = ''
+          Final store path to the generated Zed configuration.
+        '';
+      };
+    };
+  };
+
+  config = {
+    binName = mkDefault "zeditor";
+    package = mkDefault pkgs.zed-editor;
+
+    linkConfig = mkDefault true;
+
+    meta = {
+      description = ''
+        Wraps Zed with declarative settings, keymaps, tasks, debug
+        configurations, themes, extensions, and runtime PATH additions.
+      '';
+
+      maintainers = [
+        wlib.maintainers.YOUR_HANDLE
+      ];
+    };
+
+    constructFiles =
+      optionalAttrs (generatedSettings != { }) {
+        zedSettings = mkJsonFile
+          "${config.generatedConfig.relPath}/zed/settings.json"
+          generatedSettings;
+      }
+      // optionalAttrs (config.userKeymaps != [ ]) {
+        zedKeymaps = mkJsonFile
+          "${config.generatedConfig.relPath}/zed/keymap.json"
+          config.userKeymaps;
+      }
+      // optionalAttrs (config.userTasks != [ ]) {
+        zedTasks = mkJsonFile
+          "${config.generatedConfig.relPath}/zed/tasks.json"
+          config.userTasks;
+      }
+      // optionalAttrs (config.userDebug != [ ]) {
+        zedDebug = mkJsonFile
+          "${config.generatedConfig.relPath}/zed/debug.json"
+          config.userDebug;
+      }
+      // lib.mapAttrs' (
+        name: value:
+        lib.nameValuePair "zedTheme-${name}" (mkThemeFile name value)
+      ) generatedThemes;
+
+    buildCommand.zedPathThemes = mkIf (pathThemes != { }) {
+      after = [ "constructFiles" ];
+      before = [
+        "makeWrapper"
+        "symlinkScript"
+      ];
+
+      data =
+        ''
+          mkdir -p ${lib.escapeShellArg "${generatedZedConfigDir}/themes"}
+        ''
+        + lib.concatMapAttrsStringSep "\n" (
+          name: value:
+          ''
+            ln -sfn ${lib.escapeShellArg value} ${lib.escapeShellArg "${generatedZedConfigDir}/themes/${name}.json"}
+          ''
+        ) pathThemes;
+    };
+
+    runShell = mkIf (hasGeneratedConfig && config.linkConfig) [
+      {
+        name = "NIX_ZED_LINK_CONFIG";
+        "esc-fn" = wlib.escapeShellArgWithEnv;
+
+        data = ''
+          nix_zed_config=${generatedZedConfigDir}
+          user_zed_config="''${XDG_CONFIG_HOME:-$HOME/.config}/zed"
+          force_symlinks=${if config.forceSymlinks then "1" else "0"}
+
+          link_generated_zed_file() {
+            src="$1"
+            rel="''${src#$nix_zed_config/}"
+            dst="$user_zed_config/$rel"
+
+            mkdir -p "$(dirname "$dst")"
+
+            if [ -L "$dst" ]; then
+              current="$(readlink "$dst")"
+
+              if [ "$current" = "$src" ]; then
+                return 0
+              fi
+
+              if [ "$force_symlinks" = "1" ]; then
+                rm "$dst"
+              else
+                echo "zed wrapper: refusing to replace existing symlink: $dst" >&2
+                echo "zed wrapper: set forceSymlinks = true to replace it." >&2
+                exit 1
+              fi
+            elif [ -e "$dst" ]; then
+              if [ "$force_symlinks" = "1" ]; then
+                rm -rf "$dst"
+              else
+                echo "zed wrapper: refusing to replace existing file: $dst" >&2
+                echo "zed wrapper: set forceSymlinks = true to replace it." >&2
+                exit 1
+              fi
+            fi
+
+            ln -s "$src" "$dst"
+          }
+
+          if [ -d "$nix_zed_config" ]; then
+            find "$nix_zed_config" \( -type f -o -type l \) -print |
+              while IFS= read -r file; do
+                link_generated_zed_file "$file"
+              done
+          fi
+        '';
+      }
+    ];
+
+    passthru.generatedConfig = config.generatedConfig.outPath;
+  };
+}


### PR DESCRIPTION
## Summary

Adds a new `zed` wrapper module.

This provides a Home Manager-like declarative interface for Zed without depending on Home Manager. The wrapper can generate Zed config files and symlink them into the user’s `$XDG_CONFIG_HOME/zed` directory before launching Zed.

Supported options include:

* `userSettings` for `settings.json`
* `userKeymaps` for `keymap.json`
* `userTasks` for `tasks.json`
* `userDebug` for `debug.json`
* `extensions`, translated into `auto_install_extensions`
* `themes`, supporting generated JSON themes and existing theme file paths
* `linkConfig`, to control whether generated config is symlinked on launch
* `forceSymlinks`, to opt into replacing existing user config files or symlinks

## Design notes

Zed expects its configuration files in the user config directory, so this wrapper does not try to pass a custom config path to Zed. Instead, it generates the config files into the wrapper derivation using `constructFiles`, then links individual files into `$XDG_CONFIG_HOME/zed` when the wrapped binary starts.

The default behavior is intentionally conservative: existing real files or unrelated symlinks are not overwritten unless `forceSymlinks = true` is set.

## Testing

* [ ] `nix fmt`
* [ ] `nix build ./ci#checks.x86_64-linux.wrapperModule-zed -Lv`
* [ ] `nix flake check -Lv ./ci`

## Reviewer notes

I opened this as a draft because I would like feedback on the config-linking approach.

In particular, I would appreciate feedback on:

1. whether `linkConfig = true` is a good default;
2. whether the `forceSymlinks` safety behavior matches the expectations of this repository;
3. whether the option names should stay close to Home Manager’s Zed module names or use more generic wrapper-module naming.
