### PR TITLE
feat(wrapperModulers.stylua): init

### DIFF
--- a/maintainers/default.nix
+++ b/maintainers/default.nix
@@ -116,4 +116,10 @@
     github = "aliaslion";
     githubId = "122117018";
   };
+  kuppo = {
+    name = "Peng Lei";
+    email = "swk-pl@163.com";
+    github = "kuppo";
+    githubId = "17398733";
+  };
 }

--- a/wrapperModules/s/stylua/check.nix
+++ b/wrapperModules/s/stylua/check.nix
@@ -1,0 +1,99 @@
+{
+  pkgs,
+  self,
+  tlib,
+  ...
+}: let
+  inherit
+    (tlib)
+    fileContains
+    isDirectory
+    isFile
+    notIsFile
+    areEqual
+    test
+    ;
+in
+  test {wrapper = "stylua";} {
+    "stylua wrapper test" = let
+      default = self.wrappers.stylua.wrap {
+        inherit pkgs;
+      };
+      styluaWrapper = default.wrap {
+        customStyle = {
+          call_parentheses = "Always";
+          column_width = 100;
+        };
+      };
+      cpScriptWrapper = styluaWrapper.wrap {
+        generateCpScript = {
+          enable = true;
+        };
+      };
+      cpScriptNameWrapper = cpScriptWrapper.wrap {
+        generateCpScript = {
+          name = "./bin/test_script";
+        };
+      };
+      styluaTomlContent = ''
+        call_parentheses = "Always"
+        column_width = 100
+      '';
+    in [
+      (isDirectory default)
+      (notIsFile "${default}/styles/stylua.toml")
+      (notIsFile "${default}/bin/cp_stylua_toml")
+
+      (isDirectory styluaWrapper)
+      (isFile "${styluaWrapper}/styles/stylua.toml")
+      (
+        fileContains "${styluaWrapper}/styles/stylua.toml" "${styluaTomlContent}"
+      )
+      (notIsFile "${styluaWrapper}/bin/cp_stylua_toml")
+
+      (isDirectory cpScriptWrapper)
+      (isFile "${cpScriptWrapper}/styles/stylua.toml")
+      (
+        fileContains "${cpScriptWrapper}/styles/stylua.toml" "${styluaTomlContent}"
+      )
+      (isFile "${cpScriptWrapper}/bin/cp_stylua_toml")
+      (fileContains "${cpScriptWrapper}/bin/cp_stylua_toml" "bin/sh")
+
+      (isDirectory cpScriptNameWrapper)
+      (isFile "${cpScriptNameWrapper}/styles/stylua.toml")
+      (
+        fileContains "${cpScriptNameWrapper}/styles/stylua.toml" "${styluaTomlContent}"
+      )
+      (isFile "${cpScriptNameWrapper}/bin/test_script")
+      (fileContains "${cpScriptNameWrapper}/bin/test_script" "bin/sh")
+
+      # test the copy script
+      ''
+        cd /tmp && ${cpScriptNameWrapper}/bin/test_script && \
+        [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
+        grep -i "always" /tmp/stylua.toml && rm -f /tmp/stylua.toml
+      ''
+
+      ''
+        ${cpScriptNameWrapper}/bin/test_script -h |
+        grep -i "add-doc"
+      ''
+
+      ''
+        ${cpScriptNameWrapper}/bin/test_script --help |
+        grep -i "add-doc"
+      ''
+
+      ''
+        cd /tmp && ${cpScriptNameWrapper}/bin/test_script -i && \
+        [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
+        grep -i "formatting options" /tmp/stylua.toml && rm -f /tmp/stylua.toml
+      ''
+
+      ''
+        cd /tmp && ${cpScriptNameWrapper}/bin/test_script --add-doc && \
+        [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
+        grep -i "formatting options" /tmp/stylua.toml && rm -f /tmp/stylua.toml
+      ''
+    ];
+  }

--- a/wrapperModules/s/stylua/check.nix
+++ b/wrapperModules/s/stylua/check.nix
@@ -3,9 +3,9 @@
   self,
   tlib,
   ...
-}: let
-  inherit
-    (tlib)
+}:
+let
+  inherit (tlib)
     fileContains
     isDirectory
     isFile
@@ -14,8 +14,9 @@
     test
     ;
 in
-  test {wrapper = "stylua";} {
-    "stylua wrapper test" = let
+test { wrapper = "stylua"; } {
+  "stylua wrapper test" =
+    let
       default = self.wrappers.stylua.wrap {
         inherit pkgs;
       };
@@ -39,31 +40,26 @@ in
         call_parentheses = "Always"
         column_width = 100
       '';
-    in [
+    in
+    [
       (isDirectory default)
       (notIsFile "${default}/styles/stylua.toml")
       (notIsFile "${default}/bin/cp_stylua_toml")
 
       (isDirectory styluaWrapper)
       (isFile "${styluaWrapper}/styles/stylua.toml")
-      (
-        fileContains "${styluaWrapper}/styles/stylua.toml" "${styluaTomlContent}"
-      )
+      (fileContains "${styluaWrapper}/styles/stylua.toml" "${styluaTomlContent}")
       (notIsFile "${styluaWrapper}/bin/cp_stylua_toml")
 
       (isDirectory cpScriptWrapper)
       (isFile "${cpScriptWrapper}/styles/stylua.toml")
-      (
-        fileContains "${cpScriptWrapper}/styles/stylua.toml" "${styluaTomlContent}"
-      )
+      (fileContains "${cpScriptWrapper}/styles/stylua.toml" "${styluaTomlContent}")
       (isFile "${cpScriptWrapper}/bin/cp_stylua_toml")
       (fileContains "${cpScriptWrapper}/bin/cp_stylua_toml" "bin/sh")
 
       (isDirectory cpScriptNameWrapper)
       (isFile "${cpScriptNameWrapper}/styles/stylua.toml")
-      (
-        fileContains "${cpScriptNameWrapper}/styles/stylua.toml" "${styluaTomlContent}"
-      )
+      (fileContains "${cpScriptNameWrapper}/styles/stylua.toml" "${styluaTomlContent}")
       (isFile "${cpScriptNameWrapper}/bin/test_script")
       (fileContains "${cpScriptNameWrapper}/bin/test_script" "bin/sh")
 
@@ -96,4 +92,4 @@ in
         grep -i "formatting options" /tmp/stylua.toml && rm -f /tmp/stylua.toml
       ''
     ];
-  }
+}

--- a/wrapperModules/s/stylua/check.nix
+++ b/wrapperModules/s/stylua/check.nix
@@ -13,13 +13,39 @@ let
     areEqual
     test
     ;
+  default = self.wrappers.stylua.wrap {
+    inherit pkgs;
+  };
+  styluaFile = "styles/stylua.toml";
+  styluaToml = "/tmp/stylua.toml";
+  styluaTomlContent = ''
+    call_parentheses = "None"
+    column_width = 100
+    quote-style = "ForceSingle"
+  '';
 in
 test { wrapper = "stylua"; } {
-  "stylua wrapper test" =
+  "stylua default wrapper test" = [
+    (isDirectory default)
+    (notIsFile "${default}/${styluaFile}")
+    (notIsFile "${default}/bin/cp_stylua_toml")
+    # prepare the test lua file
+    ''
+      echo "print 'ugly and bad but or and good'" > /tmp/test.lua
+    ''
+    ''
+      output=$("${default}/bin/stylua" -c /tmp/test.lua 2>&1)
+      echo "$output" | grep -q 'print("ugly and bad but or and good")'
+    ''
+
+    # clean up
+    ''
+      rm /tmp/test.lua
+    ''
+  ];
+
+  "customized style wrapper test" =
     let
-      default = self.wrappers.stylua.wrap {
-        inherit pkgs;
-      };
       styluaWrapper = default.wrap {
         customStyle = {
           call_parentheses = "None";
@@ -27,36 +53,42 @@ test { wrapper = "stylua"; } {
           quote_style = "ForceSingle";
         };
       };
-      cpScriptWrapper = styluaWrapper.wrap {
-        generateCpScript = {
-          enable = true;
-        };
-      };
-      cpScriptNameWrapper = cpScriptWrapper.wrap {
-        generateCpScript = {
-          name = "./bin/test_script";
-        };
-      };
-      cpScriptOnlyWrapper = default.wrap {
-        generateCpScript.enable = true;
-      };
-      styluaTomlContent = ''
-        call_parentheses = "None"
-        column_width = 100
-        quote-style = "ForceSingle"
-      '';
-      styluaFile = "styles/stylua.toml";
-      styluaToml = "/tmp/stylua.toml";
     in
     [
-      (isDirectory default)
-      (notIsFile "${default}/${styluaFile}")
-      (notIsFile "${default}/bin/cp_stylua_toml")
-
       (isDirectory styluaWrapper)
       (isFile "${styluaWrapper}/${styluaFile}")
       (fileContains "${styluaWrapper}/${styluaFile}" "${styluaTomlContent}")
       (notIsFile "${styluaWrapper}/bin/cp_stylua_toml")
+
+      # prepare the test lua file
+      ''
+        echo "print 'ugly and bad but or and good'" > /tmp/test.lua
+      ''
+
+      ''
+        [[ $(${styluaWrapper}/bin/stylua -c /tmp/test.lua 2>&1) == "" ]]
+      ''
+
+      # clean up
+      ''
+        rm /tmp/test.lua
+      ''
+    ];
+
+  "copy script enabled wrapper test" =
+    let
+      cpScriptWrapper = default.wrap {
+        customStyle = {
+          call_parentheses = "None";
+          column_width = 100;
+          quote_style = "ForceSingle";
+        };
+        generateCpScript = {
+          enable = true;
+        };
+      };
+    in
+    [
 
       (isDirectory cpScriptWrapper)
       (isFile "${cpScriptWrapper}/${styluaFile}")
@@ -64,15 +96,32 @@ test { wrapper = "stylua"; } {
       (isFile "${cpScriptWrapper}/bin/cp_stylua_toml")
       (fileContains "${cpScriptWrapper}/bin/cp_stylua_toml" "bin/sh")
 
+      ''
+        cd /tmp && ${cpScriptWrapper}/bin/cp_stylua_toml && cat stylua.toml && rm -f ${styluaToml}
+      ''
+    ];
+
+  "customized copy script name wrapper test" =
+    let
+      cpScriptNameWrapper = default.wrap {
+        customStyle = {
+          call_parentheses = "None";
+          column_width = 100;
+          quote_style = "ForceSingle";
+        };
+        generateCpScript = {
+          enable = true;
+          name = "./bin/test_script";
+        };
+      };
+    in
+    [
+
       (isDirectory cpScriptNameWrapper)
       (isFile "${cpScriptNameWrapper}/${styluaFile}")
       (fileContains "${cpScriptNameWrapper}/${styluaFile}" "${styluaTomlContent}")
       (isFile "${cpScriptNameWrapper}/bin/test_script")
       (fileContains "${cpScriptNameWrapper}/bin/test_script" "bin/sh")
-
-      (isDirectory cpScriptOnlyWrapper)
-      (isFile "${cpScriptOnlyWrapper}/bin/cp_stylua_toml")
-      (notIsFile "${cpScriptOnlyWrapper}/${styluaFile}")
 
       ''
         cd /tmp && ${cpScriptNameWrapper}/bin/test_script && \
@@ -101,10 +150,18 @@ test { wrapper = "stylua"; } {
         [[ -e ${styluaToml} ]] && [[ -w ${styluaToml} ]] && \
         grep -i 'enabled = true|false' ${styluaToml} && rm -f ${styluaToml}
       ''
+    ];
 
-      ''
-        cd /tmp && ${cpScriptWrapper}/bin/cp_stylua_toml && cat stylua.toml && rm -f ${styluaToml}
-      ''
+  "copy script only wrapper test" =
+    let
+      cpScriptOnlyWrapper = default.wrap {
+        generateCpScript.enable = true;
+      };
+    in
+    [
+      (isDirectory cpScriptOnlyWrapper)
+      (isFile "${cpScriptOnlyWrapper}/bin/cp_stylua_toml")
+      (notIsFile "${cpScriptOnlyWrapper}/${styluaFile}")
 
       ''
         cd /tmp && ${cpScriptOnlyWrapper}/bin/cp_stylua_toml | grep "have not generated stylua.toml" \
@@ -114,25 +171,6 @@ test { wrapper = "stylua"; } {
       ''
         cd /tmp && ${cpScriptOnlyWrapper}/bin/cp_stylua_toml -i \
         && [[ -e ${styluaToml} ]] && grep 'enabled = true|false' ${styluaToml} && rm -f ${styluaToml}
-      ''
-
-      # prepare the test lua file
-      ''
-        echo "print 'ugly and bad but or and good'" > /tmp/test.lua
-      ''
-
-      ''
-        [[ $(${styluaWrapper}/bin/stylua -c /tmp/test.lua 2>&1) == "" ]]
-      ''
-
-      ''
-        output=$("${default}/bin/stylua" -c /tmp/test.lua 2>&1)
-        echo "$output" | grep -q 'print("ugly and bad but or and good")'
-      ''
-
-      # clean up
-      ''
-        rm /tmp/test.lua
       ''
     ];
 }

--- a/wrapperModules/s/stylua/check.nix
+++ b/wrapperModules/s/stylua/check.nix
@@ -85,13 +85,13 @@ test { wrapper = "stylua"; } {
       ''
         cd /tmp && ${cpScriptNameWrapper}/bin/test_script -i && \
         [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
-        grep -i "formatting options" /tmp/stylua.toml && rm -f /tmp/stylua.toml
+        grep -i 'enabled = true|false' /tmp/stylua.toml && rm -f /tmp/stylua.toml
       ''
 
       ''
         cd /tmp && ${cpScriptNameWrapper}/bin/test_script --add-doc && \
         [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
-        grep -i "formatting options" /tmp/stylua.toml && rm -f /tmp/stylua.toml
+        grep -i 'enabled = true|false' /tmp/stylua.toml && rm -f /tmp/stylua.toml
       ''
 
       ''

--- a/wrapperModules/s/stylua/check.nix
+++ b/wrapperModules/s/stylua/check.nix
@@ -37,63 +37,86 @@ test { wrapper = "stylua"; } {
           name = "./bin/test_script";
         };
       };
+      cpScriptOnlyWrapper = default.wrap {
+        generateCpScript.enable = true;
+      };
       styluaTomlContent = ''
         call_parentheses = "None"
         column_width = 100
         quote-style = "ForceSingle"
       '';
+      styluaFile = "styles/stylua.toml";
+      styluaToml = "/tmp/stylua.toml";
     in
     [
       (isDirectory default)
-      (notIsFile "${default}/styles/stylua.toml")
+      (notIsFile "${default}/${styluaFile}")
       (notIsFile "${default}/bin/cp_stylua_toml")
 
       (isDirectory styluaWrapper)
-      (isFile "${styluaWrapper}/styles/stylua.toml")
-      (fileContains "${styluaWrapper}/styles/stylua.toml" "${styluaTomlContent}")
+      (isFile "${styluaWrapper}/${styluaFile}")
+      (fileContains "${styluaWrapper}/${styluaFile}" "${styluaTomlContent}")
       (notIsFile "${styluaWrapper}/bin/cp_stylua_toml")
 
       (isDirectory cpScriptWrapper)
-      (isFile "${cpScriptWrapper}/styles/stylua.toml")
-      (fileContains "${cpScriptWrapper}/styles/stylua.toml" "${styluaTomlContent}")
+      (isFile "${cpScriptWrapper}/${styluaFile}")
+      (fileContains "${cpScriptWrapper}/${styluaFile}" "${styluaTomlContent}")
       (isFile "${cpScriptWrapper}/bin/cp_stylua_toml")
       (fileContains "${cpScriptWrapper}/bin/cp_stylua_toml" "bin/sh")
 
       (isDirectory cpScriptNameWrapper)
-      (isFile "${cpScriptNameWrapper}/styles/stylua.toml")
-      (fileContains "${cpScriptNameWrapper}/styles/stylua.toml" "${styluaTomlContent}")
+      (isFile "${cpScriptNameWrapper}/${styluaFile}")
+      (fileContains "${cpScriptNameWrapper}/${styluaFile}" "${styluaTomlContent}")
       (isFile "${cpScriptNameWrapper}/bin/test_script")
       (fileContains "${cpScriptNameWrapper}/bin/test_script" "bin/sh")
 
-      # test the copy script
+      (isDirectory cpScriptOnlyWrapper)
+      (isFile "${cpScriptOnlyWrapper}/bin/cp_stylua_toml")
+      (notIsFile "${cpScriptOnlyWrapper}/${styluaFile}")
+
       ''
         cd /tmp && ${cpScriptNameWrapper}/bin/test_script && \
-        [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
-        grep -i "forcesingle" /tmp/stylua.toml && rm -f /tmp/stylua.toml
+        [[ -e ${styluaToml} ]] && [[ -w ${styluaToml} ]] && \
+        grep -i "forcesingle" ${styluaToml} && rm -f ${styluaToml}
       ''
 
       ''
         ${cpScriptNameWrapper}/bin/test_script -h |
-        grep -i "add-doc"
+        grep -i "add-doc" && [[ ! -e ${styluaToml} ]]
       ''
 
       ''
         ${cpScriptNameWrapper}/bin/test_script --help |
-        grep -i "add-doc"
+        grep -i "add-doc" && [[ ! -e ${styluaToml} ]]
       ''
 
       ''
         cd /tmp && ${cpScriptNameWrapper}/bin/test_script -i && \
-        [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
-        grep -i 'enabled = true|false' /tmp/stylua.toml && rm -f /tmp/stylua.toml
+        [[ -e ${styluaToml} ]] && [[ -w ${styluaToml} ]] && \
+        grep -i 'enabled = true|false' ${styluaToml} && rm -f ${styluaToml}
       ''
 
       ''
         cd /tmp && ${cpScriptNameWrapper}/bin/test_script --add-doc && \
-        [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
-        grep -i 'enabled = true|false' /tmp/stylua.toml && rm -f /tmp/stylua.toml
+        [[ -e ${styluaToml} ]] && [[ -w ${styluaToml} ]] && \
+        grep -i 'enabled = true|false' ${styluaToml} && rm -f ${styluaToml}
       ''
 
+      ''
+        cd /tmp && ${cpScriptWrapper}/bin/cp_stylua_toml && cat stylua.toml && rm -f ${styluaToml}
+      ''
+
+      ''
+        cd /tmp && ${cpScriptOnlyWrapper}/bin/cp_stylua_toml | grep "have not generated stylua.toml" \
+        && [[ ! -e ${styluaToml} ]]
+      ''
+
+      ''
+        cd /tmp && ${cpScriptOnlyWrapper}/bin/cp_stylua_toml -i \
+        && [[ -e ${styluaToml} ]] && grep 'enabled = true|false' ${styluaToml} && rm -f ${styluaToml}
+      ''
+
+      # prepare the test lua file
       ''
         echo "print 'ugly and bad but or and good'" > /tmp/test.lua
       ''
@@ -107,8 +130,9 @@ test { wrapper = "stylua"; } {
         echo "$output" | grep -q 'print("ugly and bad but or and good")'
       ''
 
+      # clean up
       ''
-        cd /tmp && ${cpScriptWrapper}/bin/cp_stylua_toml && cat stylua.toml
+        rm /tmp/test.lua
       ''
     ];
 }

--- a/wrapperModules/s/stylua/check.nix
+++ b/wrapperModules/s/stylua/check.nix
@@ -22,8 +22,9 @@ test { wrapper = "stylua"; } {
       };
       styluaWrapper = default.wrap {
         customStyle = {
-          call_parentheses = "Always";
+          call_parentheses = "None";
           column_width = 100;
+          quote_style = "ForceSingle";
         };
       };
       cpScriptWrapper = styluaWrapper.wrap {
@@ -37,8 +38,9 @@ test { wrapper = "stylua"; } {
         };
       };
       styluaTomlContent = ''
-        call_parentheses = "Always"
+        call_parentheses = "None"
         column_width = 100
+        quote-style = "ForceSingle"
       '';
     in
     [
@@ -67,7 +69,7 @@ test { wrapper = "stylua"; } {
       ''
         cd /tmp && ${cpScriptNameWrapper}/bin/test_script && \
         [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
-        grep -i "always" /tmp/stylua.toml && rm -f /tmp/stylua.toml
+        grep -i "forcesingle" /tmp/stylua.toml && rm -f /tmp/stylua.toml
       ''
 
       ''
@@ -90,6 +92,23 @@ test { wrapper = "stylua"; } {
         cd /tmp && ${cpScriptNameWrapper}/bin/test_script --add-doc && \
         [[ -e /tmp/stylua.toml ]] && [[ -w /tmp/stylua.toml ]] && \
         grep -i "formatting options" /tmp/stylua.toml && rm -f /tmp/stylua.toml
+      ''
+
+      ''
+        echo "print 'ugly and bad but or and good'" > /tmp/test.lua
+      ''
+
+      ''
+        [[ $(${styluaWrapper}/bin/stylua -c /tmp/test.lua 2>&1) == "" ]]
+      ''
+
+      ''
+        output=$("${default}/bin/stylua" -c /tmp/test.lua 2>&1)
+        echo "$output" | grep -q 'print("ugly and bad but or and good")'
+      ''
+
+      ''
+        cd /tmp && ${cpScriptWrapper}/bin/cp_stylua_toml && cat stylua.toml
       ''
     ];
 }

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -4,8 +4,9 @@
   config,
   pkgs,
   ...
-}: {
-  imports = [wlib.modules.default];
+}:
+{
+  imports = [ wlib.modules.default ];
 
   options = {
     customStyle = lib.mkOption {
@@ -13,7 +14,7 @@
         nullable = false;
         typeName = "TOML";
       };
-      default = {};
+      default = { };
       description = ''
         nix configuration for the stylua.
 
@@ -32,7 +33,7 @@
       '';
     };
     generateCpScript = lib.mkOption {
-      default = {};
+      default = { };
       description = ''
         Options for copy script which help you quickly copy your
         settings into `$CWD` for further customization.
@@ -63,38 +64,41 @@
   };
   config = {
     package = lib.mkDefault pkgs.stylua;
-    constructFiles.generatedConfig = lib.mkIf (config.customStyle
-      != {}) {
+    constructFiles.generatedConfig = lib.mkIf (config.customStyle != { }) {
       content = builtins.toJSON config.customStyle;
       relPath = "styles/stylua.toml";
       builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     };
-    constructFiles."${baseNameOf config.generateCpScript.name}" = lib.mkIf config.generateCpScript.enable {
-      relPath = "bin/${baseNameOf config.generateCpScript.name}";
-      builder = "cp $1 $2 && chmod +x $2";
-      content = ''
-        #!${pkgs.bash}/bin/sh
-        help=$'cp_stylua_toml [-h|--help|-i|--add-doc]\nCopy stylua files.\nOptions:\n\t-h|--help\tPrint this help\n\t-i|--add-doc\tAdd the configuration doccumentation to the end of the stylua.toml'
+    constructFiles."${baseNameOf config.generateCpScript.name}" =
+      lib.mkIf config.generateCpScript.enable
+        {
+          relPath = "bin/${baseNameOf config.generateCpScript.name}";
+          builder = "cp $1 $2 && chmod +x $2";
+          content = ''
+            #!${pkgs.bash}/bin/sh
+            help=$'cp_stylua_toml [-h|--help|-i|--add-doc]\nCopy stylua files.\nOptions:\n\t-h|--help\tPrint this help\n\t-i|--add-doc\tAdd the configuration doccumentation to the end of the stylua.toml'
 
-        target=$(pwd)/stylua.toml
+            target=$(pwd)/stylua.toml
 
-        doc=$(${placeholder config.outputName}/bin/stylua --help \
-        | ${pkgs.gnused}/bin/sed -n \
-        '/^FORMATTING OPTIONS:$/,$ {1d;s/^[[:space:]]*/   /;s/^[[:space:]]*--/** /;s/^/# /;p}')
+            doc=$(${placeholder config.outputName}/bin/stylua --help \
+            | ${pkgs.gnused}/bin/sed -n \
+            '/^FORMATTING OPTIONS:$/,$ {1d;s/^[[:space:]]*/   /;s/^[[:space:]]*--/** /;s/^/# /;p}')
 
-        if [ "$#" -ne 1 ]; then
-          cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \
-          && chmod u+w "$target"
-        elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
-          echo "$help"
-          exit 0
-        elif [ "$1" == "-i" ] || [ "$1" == "--add-doc" ]; then
-          cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \
-          && chmod u+w "$target" && echo >> "$target" && echo "$doc" >> "$target"
-        fi
-      '';
-    };
-    flags."--config-path" = lib.mkIf (config.customStyle != {}) config.constructFiles.generatedConfig.path;
+            if [ "$#" -ne 1 ]; then
+              cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \
+              && chmod u+w "$target"
+            elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+              echo "$help"
+              exit 0
+            elif [ "$1" == "-i" ] || [ "$1" == "--add-doc" ]; then
+              cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \
+              && chmod u+w "$target" && echo >> "$target" && echo "$doc" >> "$target"
+            fi
+          '';
+        };
+    flags."--config-path" = lib.mkIf (
+      config.customStyle != { }
+    ) config.constructFiles.generatedConfig.path;
     meta = {
       maintainers = with wlib.maintainers; [
         kuppo

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -1,0 +1,113 @@
+{
+  wlib,
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+{
+  imports = [ wlib.modules.default ];
+
+  options = {
+    defaultStyle = lib.mkOption {
+      type = lib.types.attrs;
+      readOnly = true;
+      description = ''
+        Default settings for the `stylua.toml` (read only).
+      '';
+      default = {
+        syntax = "All";
+        column_width = 120;
+        line_endings = "Unix";
+        indent_type = "Tabs";
+        indent_width = 4;
+        quote_style = "AutoPreferDouble";
+        call_parentheses = "Always";
+        collapse_simple_statement = "Never";
+        space_after_function_names = "Never";
+        block_newline_gaps = "Never";
+        sort_requires = {
+          enabled = false;
+        };
+      };
+    };
+    customStyle = lib.mkOption {
+      type = wlib.types.structuredValueWith {
+        nullable = false;
+        typeName = "TOML";
+      };
+      default = { };
+      description = ''
+        nix configuration for the stylua.
+
+        Check [StyLua options](https://github.com/JohnnyMorganz/StyLua/blob/main/README.md#options).
+      '';
+      example = lib.literalExpression ''
+        settings = {
+          call_parentheses = "Always";
+          column_width = 100;
+          collapse_simple_statement = "Always";
+          indent_type = "Spaces";
+          indent_width = 2;
+          quote_style = "ForceDouble";
+          sort_requires.enabled = true;
+        };
+      '';
+    };
+    generateCpScript = lib.mkEnableOption ''
+      generate a copy script.
+
+      The script `cp_stylua_toml` copys the generated `stylua.toml` file into the $CWD
+      in case you want to include it in the repo.
+      With the `-d|--default` option, will copy the default configuration file
+      (named `stylua.default.toml`).
+      Both files include all available options.
+    '';
+  };
+  config = {
+    package = lib.mkDefault pkgs.stylua;
+    constructFiles."stylua.default.toml" = {
+      content = builtins.toJSON config.defaultStyle;
+      relPath = "styles/stylua.default.toml";
+      builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+    };
+    constructFiles."stylua.toml" = {
+      content = builtins.toJSON (lib.recursiveUpdate config.defaultStyle config.customStyle);
+      relPath = "styles/stylua.toml";
+      builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+    };
+    constructFiles."cp_stylua_toml" = lib.mkIf config.generateCpScript {
+      relPath = "bin/cp_stylua_toml";
+      builder = "cp $1 $2 && chmod +x $2";
+      content = ''
+        #!${pkgs.bash}/bin/sh
+        help=$'cp_stylua_toml [-h|--help|-d|--default]\nCopy stylua files.\nOptions:\n\t-h|--help\tPrint this help\n\t-d|--default\tCopy the default style file'
+        if [ "$#" -ne 1 ]; then
+          source=${placeholder config.outputName}/styles/stylua.toml
+        elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+          echo "$help"
+          exit 0
+        elif [ "$1" == "-d" ] || [ "$1" == "--default" ]; then
+          source=${placeholder config.outputName}/styles/stylua.default.toml
+        fi
+        cp $source $(pwd)/
+      '';
+    };
+    flags."--config-path" = config.constructFiles."stylua.toml".path;
+    meta = {
+      maintainers = with wlib.maintainers; [
+        kuppo
+      ];
+      description = ''
+        Wrapper Module for [Stylua](https://github.com/JohnnyMorganz/StyLua).
+
+        The wrapper is used to customize the `stylua.toml` file. 
+        You can add you options into `config.customStyle` with pure nix expressions.
+
+        The wrapper also provides a script which copys the generated `stylua.toml` or
+        the default style file into the CWD,
+        in case you want to include the confitugation into the repo.
+      '';
+    };
+  };
+}

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -103,12 +103,12 @@
       description = ''
         Wrapper Module for [Stylua](https://github.com/JohnnyMorganz/StyLua).
 
-        The wrapper is used to customize the `stylua.toml` file. 
+        The wrapper is used to customize the `stylua.toml` file.
         You can add you options into `config.customStyle` with pure nix expressions.
 
-        The wrapper also provides a script which copys the generated `stylua.toml` or
-        the default style file into the CWD,
-        in case you want to include the confitugation into the repo.
+        The wrapper also provides a script which copys the generated `stylua.toml`
+        into `$CWD`, in case you want to include the confitugation into the repo or
+        customize it somehow.
       '';
     };
   };

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -32,15 +32,35 @@
         };
       '';
     };
-    generateCpScript = lib.mkEnableOption ''
-      generate a copy script.
+    generateCpScript = lib.mkOption {
+      default = {};
+      description = ''
+        Options for copy script which help you quickly copy your
+        settings into `$CWD` for further customization.
 
-      The script `cp_stylua_toml` copys the generated `stylua.toml` file into the $CWD
-      in case you want to include it in the repo.
-      With the `-d|--default` option, will copy the default configuration file
-      (named `stylua.default.toml`).
-      Both files include all available options.
-    '';
+        The script `cp_stylua_toml` (name is customizable) copys the generated
+        `stylua.toml` file into '$CWD' in case you want to include it in the
+        repo or customize it.
+
+        With the `-i|--add-doc` option, it will add the configuraiton
+        documentation to the end of the copied file.
+      '';
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption ''
+            generating a copy script.
+          '';
+          name = lib.mkOption {
+            type = lib.types.str;
+            default = "cp_stylua_toml";
+            description = ''
+              Customize the name of the copy script. If the name has `/` in it,
+              the wrapper will only take the file's base name.
+            '';
+          };
+        };
+      };
+    };
   };
   config = {
     package = lib.mkDefault pkgs.stylua;
@@ -50,21 +70,29 @@
       relPath = "styles/stylua.toml";
       builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     };
-    constructFiles."cp_stylua_toml" = lib.mkIf config.generateCpScript {
-      relPath = "bin/cp_stylua_toml";
+    constructFiles."${baseNameOf config.generateCpScript.name}" = lib.mkIf config.generateCpScript.enable {
+      relPath = "bin/${baseNameOf config.generateCpScript.name}";
       builder = "cp $1 $2 && chmod +x $2";
       content = ''
         #!${pkgs.bash}/bin/sh
-        help=$'cp_stylua_toml [-h|--help|-d|--default]\nCopy stylua files.\nOptions:\n\t-h|--help\tPrint this help\n\t-d|--default\tCopy the default style file'
+        help=$'cp_stylua_toml [-h|--help|-i|--add-doc]\nCopy stylua files.\nOptions:\n\t-h|--help\tPrint this help\n\t-i|--add-doc\tAdd the configuration doccumentation to the end of the stylua.toml'
+
+        target=$(pwd)/stylua.toml
+
+        doc=$(${placeholder config.outputName}/bin/stylua --help \
+        | ${pkgs.gnused}/bin/sed -n \
+        '/^FORMATTING OPTIONS:$/,$ {1d;s/^[[:space:]]*/   /;s/^[[:space:]]*--/** /;s/^/# /;p}')
+
         if [ "$#" -ne 1 ]; then
-          source=${placeholder config.outputName}/styles/stylua.toml
+          cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \
+          && chmod u+w "$target"
         elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
           echo "$help"
           exit 0
-        elif [ "$1" == "-d" ] || [ "$1" == "--default" ]; then
-          source=${placeholder config.outputName}/styles/stylua.default.toml
+        elif [ "$1" == "-i" ] || [ "$1" == "--add-doc" ]; then
+          cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \
+          && chmod u+w "$target" && echo >> "$target" && echo "$doc" >> "$target"
         fi
-        cp $source $(pwd)/
       '';
     };
     flags."--config-path" = config.constructFiles."stylua.toml".path;

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -94,7 +94,7 @@
         fi
       '';
     };
-    flags."--config-path" = config.constructFiles."stylua.toml".path;
+    flags."--config-path" = lib.mkIf (config.customStyle != {}) config.constructFiles.generatedConfig.path;
     meta = {
       maintainers = with wlib.maintainers; [
         kuppo

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -4,9 +4,8 @@
   config,
   pkgs,
   ...
-}:
-{
-  imports = [ wlib.modules.default ];
+}: {
+  imports = [wlib.modules.default];
 
   options = {
     customStyle = lib.mkOption {
@@ -14,7 +13,7 @@
         nullable = false;
         typeName = "TOML";
       };
-      default = { };
+      default = {};
       description = ''
         nix configuration for the stylua.
 

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -9,28 +9,6 @@
   imports = [ wlib.modules.default ];
 
   options = {
-    defaultStyle = lib.mkOption {
-      type = lib.types.attrs;
-      readOnly = true;
-      description = ''
-        Default settings for the `stylua.toml` (read only).
-      '';
-      default = {
-        syntax = "All";
-        column_width = 120;
-        line_endings = "Unix";
-        indent_type = "Tabs";
-        indent_width = 4;
-        quote_style = "AutoPreferDouble";
-        call_parentheses = "Always";
-        collapse_simple_statement = "Never";
-        space_after_function_names = "Never";
-        block_newline_gaps = "Never";
-        sort_requires = {
-          enabled = false;
-        };
-      };
-    };
     customStyle = lib.mkOption {
       type = wlib.types.structuredValueWith {
         nullable = false;
@@ -66,13 +44,9 @@
   };
   config = {
     package = lib.mkDefault pkgs.stylua;
-    constructFiles."stylua.default.toml" = {
-      content = builtins.toJSON config.defaultStyle;
-      relPath = "styles/stylua.default.toml";
-      builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
-    };
-    constructFiles."stylua.toml" = {
-      content = builtins.toJSON (lib.recursiveUpdate config.defaultStyle config.customStyle);
+    constructFiles.generatedConfig = lib.mkIf (config.customStyle
+      != {}) {
+      content = builtins.toJSON config.customStyle;
       relPath = "styles/stylua.toml";
       builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     };

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -81,8 +81,7 @@
             target=$(pwd)/stylua.toml
 
             doc=$(${placeholder config.outputName}/bin/stylua --help \
-            | ${pkgs.gnused}/bin/sed -n \
-            '/^FORMATTING OPTIONS:$/,$ {1d;s/^[[:space:]]*/   /;s/^[[:space:]]*--/** /;s/^/# /;p}')
+            | ${pkgs.gawk}/bin/awk '/^FORMATTING OPTIONS:/{f=1;next}f{sub(/^[[:space:]]*/,"");if($0=="")next;sub(/^--/,"** ");gsub(/ *<[^>]*>/,"");gsub(/-/,"_");if($0=="Enable requires sorting")$0=$0" [enabled = true|false]";if(/^\*\*/)printf "\n";print "# "$0}')
 
             if [ "$#" -ne 1 ]; then
               cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -38,10 +38,7 @@
         Options for copy script which help you quickly copy your
         settings into `$CWD` for further customization.
 
-        The script `cp_stylua_toml` (name is customizable) copys the generated
-        `stylua.toml` file into '$CWD' in case you want to include it in the
-        repo or customize it.
-
+        The script's name can be customized.
         With the `-i|--add-doc` option, it will add the configuraiton
         documentation to the end of the copied file.
       '';
@@ -50,16 +47,16 @@
           enable = lib.mkEnableOption ''
             generating a copy script.
 
-            If you don't add `customStyle`, the script will ofcause copy nothing.
-            But you can use the `-i|--add-doc` option to generate one with documentation added
-            file.
+            If you don't add `customStyle`, the script will of cause copy nothing.
+            But you can use the `-i|--add-doc` option to generate one with only
+            documentation added.
           '';
           name = lib.mkOption {
             type = lib.types.str;
             default = "cp_stylua_toml";
             description = ''
               Customize the name of the copy script. If the name has `/` in it,
-              the wrapper will only take the file's base name.
+              the wrapper will ignore and only take the base name.
             '';
           };
         };

--- a/wrapperModules/s/stylua/module.nix
+++ b/wrapperModules/s/stylua/module.nix
@@ -49,6 +49,10 @@
         options = {
           enable = lib.mkEnableOption ''
             generating a copy script.
+
+            If you don't add `customStyle`, the script will ofcause copy nothing.
+            But you can use the `-i|--add-doc` option to generate one with documentation added
+            file.
           '';
           name = lib.mkOption {
             type = lib.types.str;
@@ -79,19 +83,22 @@
             help=$'cp_stylua_toml [-h|--help|-i|--add-doc]\nCopy stylua files.\nOptions:\n\t-h|--help\tPrint this help\n\t-i|--add-doc\tAdd the configuration doccumentation to the end of the stylua.toml'
 
             target=$(pwd)/stylua.toml
+            source=${placeholder config.outputName}/styles/stylua.toml
 
             doc=$(${placeholder config.outputName}/bin/stylua --help \
             | ${pkgs.gawk}/bin/awk '/^FORMATTING OPTIONS:/{f=1;next}f{sub(/^[[:space:]]*/,"");if($0=="")next;sub(/^--/,"** ");gsub(/ *<[^>]*>/,"");gsub(/-/,"_");if($0=="Enable requires sorting")$0=$0" [enabled = true|false]";if(/^\*\*/)printf "\n";print "# "$0}')
 
             if [ "$#" -ne 1 ]; then
-              cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \
-              && chmod u+w "$target"
+              [[ ! -e "$source" ]] \
+              && echo "You have not generated stylua.toml. You can use -i|--add-doc option to add a stylua.toml with only documentation included." \
+              && exit 0
+              cp -f "$source" "$target" && chmod u+w "$target"
             elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
               echo "$help"
               exit 0
             elif [ "$1" == "-i" ] || [ "$1" == "--add-doc" ]; then
-              cp -f ${placeholder config.outputName}/styles/stylua.toml $(pwd)/ \
-              && chmod u+w "$target" && echo >> "$target" && echo "$doc" >> "$target"
+              [[ -e "$source" ]] && cp -f "$source" "$target"
+              touch "$target" && chmod u+w "$target" && echo "$doc" >> "$target"
             fi
           '';
         };


### PR DESCRIPTION
This PR add a wrapper for stylua.

It mainly used to configure the style of the stylua. You can add nix expression of the configuration and it will generate the stylua.toml file for you. Additionally, you can enable the wrapper to generate a copy script which copy the generated configuration file into CWD in case people want to customize individual style or want to include it into the repo.