### PR TITLE
feat: added a wrapper for `neovide`

### DIFF
--- a/maintainers/default.nix
+++ b/maintainers/default.nix
@@ -116,4 +116,9 @@
     github = "aliaslion";
     githubId = "122117018";
   };
+  nuclear-squid = {
+    name = "Nuclear-Squid";
+    github = "Nuclear-Squid";
+    githubId = 70967142;
+  };
 }

--- a/wrapperModules/n/neovide/module.nix
+++ b/wrapperModules/n/neovide/module.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  wlib,
+  pkgs,
+  ...
+}:
+{
+  imports = [ wlib.modules.default ];
+  options = {
+    settings = lib.mkOption {
+      type = wlib.types.structuredValueWith {
+        nullable = false;
+        typeName = "TOML";
+      };
+      default = {};
+      description = ''
+        Configuration passed to neovide using the `NEOVIDE_CONFIG` environment variable.
+        See <https://neovide.dev/config-file.html> for the config options.
+      '';
+    };
+    config = {
+      package = pkgs.neovide;
+      env.NEOVIDE_CONFIG = "${config.binDir}/config.toml";
+      constructFiles.generatedConfig = {
+        content = builtins.toJSON config.settings;
+        relPath = "${config.binDir}/config.toml";
+        builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
+      };
+      meta.maintainers = [ wlib.maintainers.nuclear-squid ];
+    };
+  };
+}


### PR DESCRIPTION
As the title says, this PR adds a wrapper module for `neovide`, a fancy GUI for Neovim. It can be configured in two places (for two different usages) :
- there’s a toml config file for things that are mostly static (like the font you use, or where to log backtraces): https://neovide.dev/config-file.html
- there’s a bit of lua config, which is specified (with a guard) in your neovim config: https://neovide.dev/configuration.html

This PR only handles the first one (the config file) as I go over the assumption that you’ll have your lua config with the rest of your neovim config. (I’m also not really sure if that would be possible to implement, since wrapped packages seem to be independent)

First time opening a PR, hopefully I didn’t mess it up too much :sweat_smile: 