### PR TITLE
feat(test-lib): add notFileContains helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,7 @@ of the wrapper (if any) and ensure that the tests are only run on the required p
 let
   inherit (tlib)
     fileContains
+    fileNotContains
     isDirectory
     isFile
     notIsFile
@@ -202,7 +203,7 @@ test { wrapper = "direnv"; } { # <-- Specify the name of the wrapper here (*)
     in
     [
       "[[ -d ${wrapper} ]]" # <-- a simple condition to be asserted
-      {                     
+      {
         cond = "[[ -d ${wrapper} ]]";
         msg = "No directory found for wrapper."; # <-- you can also specify a custom error message
       }
@@ -214,7 +215,7 @@ test { wrapper = "direnv"; } { # <-- Specify the name of the wrapper here (*)
       wrapper = self.wrappers.direnv.wrap {
         inherit pkgs;
       };
-    in 
+    in
     '' # <-- no need to provide a list if there is only one assertion
       "${wrapper}/bin/direnv" --version |
       grep -q "${wrapper.version}"
@@ -253,6 +254,7 @@ except you don't provide a wrapper but a name:
 let
   inherit (tlib)
     fileContains
+    fileNotContains
     isDirectory
     isFile
     notIsFile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ of the wrapper (if any) and ensure that the tests are only run on the required p
 let
   inherit (tlib)
     fileContains
-    fileNotContains
+    notFileContains
     isDirectory
     isFile
     notIsFile
@@ -254,7 +254,7 @@ except you don't provide a wrapper but a name:
 let
   inherit (tlib)
     fileContains
-    fileNotContains
+    notFileContains
     isDirectory
     isFile
     notIsFile

--- a/ci/test-lib.nix
+++ b/ci/test-lib.nix
@@ -320,6 +320,28 @@ in
   };
 
   /**
+    Returns an `Assertion` that checks whether `file` does not contain a line matching `pattern`.
+
+    The check is performed with `! grep -Eq`, so `pattern` is treated as an extended regular expression.
+
+    # Type
+    ```
+    fileNotContains :: String -> String -> Assertion
+    ```
+
+    # Arguments
+    file
+    : Path to the file to search.
+
+    pattern
+    : Extended regular expression to search for.
+  */
+  fileNotContains = file: pattern: {
+    cond = ''! grep -Eq -- '${pattern}' "${file}"'';
+    msg = "Pattern '${pattern}' found in ${file}";
+  };
+
+  /**
     Returns an `Assertion` that checks whether `expected` and `actual` are equal.
 
     The comparison is performed in Nix at evaluation time. If the values differ,

--- a/ci/test-lib.nix
+++ b/ci/test-lib.nix
@@ -326,7 +326,7 @@ in
 
     # Type
     ```
-    fileNotContains :: String -> String -> Assertion
+    notFileContains :: String -> String -> Assertion
     ```
 
     # Arguments
@@ -336,7 +336,7 @@ in
     pattern
     : Extended regular expression to search for.
   */
-  fileNotContains = file: pattern: {
+  notFileContains = file: pattern: {
     cond = ''! grep -Eq -- '${pattern}' "${file}"'';
     msg = "Pattern '${pattern}' found in ${file}";
   };


### PR DESCRIPTION
This adds a complementary helper (to already existed `fileContains`) -- `fileNotContains` for simple comparison.

Generally it just negates result of `grep` expression from `fileContains` helper. 