### PR TITLE
fix(wrapperModules.jujutsu): update itself in compltetions files

### DIFF
--- a/wrapperModules/j/jujutsu/module.nix
+++ b/wrapperModules/j/jujutsu/module.nix
@@ -31,6 +31,12 @@
       relPath = "${config.binName}-config.toml";
       builder = ''${pkgs.remarshal}/bin/json2toml "$1" "$2"'';
     };
+    # Update itself in completion files so it can autocomplete aliases declared in config
+    filesToPatch = [
+      "share/bash-completion/completions/jj.bash"
+      "share/fish/vendor_completions.d/jj.fish"
+      "share/zsh/site-functions/_jj"
+    ];
 
     meta.maintainers = [ wlib.maintainers.birdee ];
   };


### PR DESCRIPTION
Jujutsu's can autocomplete aliases declared in its config, but jujutsu from those autocompletion files should know about the configured aliases, so it's better to override it by default with configured/wrapped binary.

This resolves frustration I had when I couldn't get autocompletion works as expected. 
Also, I tested it only on zsh, but added all completion files assuming all shells works the same way regarding this issue.

P.S.: this same issue might affect git as well. But I haven't gotten around configuring wrapped version of git yet to confirm it.