### PR TITLE
feat(wlib.toKdl): add custom value to support literal regex props

### DIFF
--- a/ci/checks/toKdl.nix
+++ b/ci/checks/toKdl.nix
@@ -61,6 +61,17 @@ let
       };
     }
     {
+      description = "function with props custom content";
+      expected = ''"h" "k"=r#"v"#'';
+      actual = toKdl {
+        h = _: {
+          props = {
+            k = _: { custom = ''r#"v"#''; };
+          };
+        };
+      };
+    }
+    {
       description = "function with content only";
       expected = "\"i\"  {\n  \"j\" 1\n}";
       actual = toKdl {
@@ -73,12 +84,13 @@ let
     }
     {
       description = "function with props and content";
-      expected = "\"f\" \"arg1\" \"key\"=\"val\" {\n  \"g\" \n}";
+      expected = "\"f\" \"arg1\" \"key1\"=\"val\" \"key2\"=r#\"val\"# {\n  \"g\" \n}";
       actual = toKdl {
         f = _: {
           props = [
             "arg1"
-            { key = "val"; }
+            { key1 = "val"; }
+            { key2 = _: { custom = ''r#"val"#''; }; }
           ];
           content = {
             g = _: { };

--- a/lib/toKdl.nix
+++ b/lib/toKdl.nix
@@ -19,7 +19,8 @@ let
                 res = lib.fix v;
               in
               lib.optionalString (res ? type) "(${toString res.type})"
-              + lib.optionalString (res ? content) "${toJSON res.content}"
+              + lib.optionalString (res ? content && !res ? custom) "${toJSON res.content}"
+              + lib.optionalString (res ? custom) res.custom
             else if isAttrs v || isList v then
               toJSON (toJSON v)
             else

--- a/wrapperModules/n/niri/check.nix
+++ b/wrapperModules/n/niri/check.nix
@@ -25,6 +25,7 @@ let
           matches = [ { app-id = ".*"; } ];
           excludes = [
             { app-id = "org.keepassxc.KeePassXC"; }
+            { app-id = _: { custom = ''r#"^org\.telegram\.desktop$"#''; }; }
           ];
           open-focused = false;
           open-floating = false;

--- a/wrapperModules/n/niri/module.nix
+++ b/wrapperModules/n/niri/module.nix
@@ -163,6 +163,7 @@ in
                 matches = [ { app-id = ".*"; } ];
                 excludes = [
                   { app-id = "org.keepassxc.KeePassXC"; }
+                  { app-id = _: { custom = ''r#"^org\.telegram\.desktop$"#''; }; }
                 ];
                 open-focused = false;
                 open-floating = false;


### PR DESCRIPTION
Adds an `_raw` attribute to be able to use raw literals in kdl, e.g.

```nix
excludes = [  { app-id._raw = "^org\.telegram\.desktop$"; } ];
```

to produce

```kdl
exclude app-id=r#"^org\.telegram\.desktop$"#
```

as show in the [niri docs](https://niri-wm.github.io/niri/Configuration%3A-Window-Rules.html#title-and-app-id)

Fixes https://github.com/BirdeeHub/nix-wrapper-modules/discussions/566