### PR TITLE
fix(wrapperModules.fish): fix abbreviation argument order

### DIFF
--- a/wrapperModules/f/fish/module.nix
+++ b/wrapperModules/f/fish/module.nix
@@ -468,10 +468,9 @@ in
 
         mkAbbrStr =
           abbr:
-          (foldl' (
-            acc: elem: acc + " " + (mkAbbrArg elem abbr)
-          ) "abbr --add ${abbr.word} ${mkCursorArg abbr}" abbrArgs)
-          + optionalString (abbr.function == null) " \"${abbr.expansion}\"";
+          (foldl' (acc: elem: acc + " " + (mkAbbrArg elem abbr)) "abbr --add ${mkCursorArg abbr}" abbrArgs)
+          + " -- ${abbr.word}"
+          + optionalString (abbr.function == null) " ${lib.escapeShellArg abbr.expansion}";
 
         abbrs = concatStringsSep "\n" (map mkAbbrStr (attrValues cfg.abbreviations));
         aliases = concatStringsSep "\n" (
@@ -485,9 +484,11 @@ in
         pluginCompletions
         customPluginSources
         customPluginCompletions
+        "if status is-interactive"
         aliases
         abbrs
         completions
+        "end"
         cfg.configFile.content
       ]);
   };

--- a/wrapperModules/f/fish/module.nix
+++ b/wrapperModules/f/fish/module.nix
@@ -45,7 +45,7 @@ let
             "anywhere"
             "command"
           ];
-          default = "anywhere";
+          default = "command";
           description = ''
             The scope of the abbreviation.
 


### PR DESCRIPTION
Currently, doing

```nix
abbreviations = {
  "--help" = {
    expansion = "--help | bat --plain --language=help";
    position = "anywhere";
  };
};
```

generates

```fish
abbr --add --help  --position anywhere    "--help | bat --plain --language=help"
```
which results in `abbr --help` being called instead of the abbreviation being set.

This fix changes it to generate the following instead.

```fish
abbr --add  --position anywhere    -- --help "--help | bat --plain --language=help"
```

I've also wrapped the shellAliases and abbreviations to only be evaluated in interactive shells. Any output produced by fish breaks completion generation, since it gets prepended to the python completion generator: https://github.com/NixOS/nixpkgs/blame/6368bc923cec55a5f78960ade0cb4dd99580e087/nixos/modules/programs/fish.nix#L273

I've also set the abbreviation position to "command" as outlined in #582. If this is not desired, I can remove this change.

@ormoyo 