### PR TITLE
chore(wrapperModules.neovim): stdenv.isLinux -> stdenv.hostPlatform.isLinux

### DIFF
--- a/wrapperModules/n/neovim/symlinkScript.nix
+++ b/wrapperModules/n/neovim/symlinkScript.nix
@@ -168,7 +168,7 @@ finalDrv
     ) outputs}
 
   ''
-  + lib.optionalString stdenv.isLinux (
+  + lib.optionalString stdenv.hostPlatform.isLinux (
     patchDesktop "nvim" binName + patchDesktop "org.neovim.nvim" "org.neovim.${binName}"
   );
 }


### PR DESCRIPTION
Raises a warning: `stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead`