### PR TITLE
fix(wrapperModules.niri): support niri development version

### DIFF
--- a/wrapperModules/n/niri/module.nix
+++ b/wrapperModules/n/niri/module.nix
@@ -354,21 +354,19 @@ in
         + "\n"
         + config.settings.extraConfig;
   };
-  config.buildCommand.niriReloadConfig =
-    lib.mkIf (!config.disableConfigHotReload && lib.versionAtLeast config.package.version "26.04")
-      {
-        after = [ "symlinkScript" ];
-        data = ''
-          chmod +w ${placeholder config.outputName}/share/systemd/user/niri.service
-          cat >> ${placeholder config.outputName}/share/systemd/user/niri.service<<EOF
-          [Unit]
-          X-Reload-Triggers=${config.constructFiles.generatedConfig.path}
-          [Service]
-          ExecReload=${lib.getExe config.package} msg action load-config-file --path ${config.constructFiles.generatedConfig.path}
-          X-ReloadIfChanged=true
-          EOF
-        '';
-      };
+  config.buildCommand.niriReloadConfig = lib.mkIf (!config.disableConfigHotReload) {
+    after = [ "symlinkScript" ];
+    data = ''
+      chmod +w ${placeholder config.outputName}/share/systemd/user/niri.service
+      cat >> ${placeholder config.outputName}/share/systemd/user/niri.service<<EOF
+      [Unit]
+      X-Reload-Triggers=${config.constructFiles.generatedConfig.path}
+      [Service]
+      ExecReload=${lib.getExe config.package} msg action load-config-file --path ${config.constructFiles.generatedConfig.path}
+      X-ReloadIfChanged=true
+      EOF
+    '';
+  };
   config.meta.maintainers = [
     wlib.maintainers.patwid
   ];


### PR DESCRIPTION
Fixes #584 by dropping the version check. Both nixpkgs 26.05 and unstable are now also on niri v26.04 so this check is no longer necessary.