### PR TITLE
fix(wrapperModules.mangowc): on unstable, pkgs.mangowc is now named pkgs.mango

### DIFF
--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -250,7 +250,7 @@
     };
 
     flags."-c" = config.configFile.path;
-    package = lib.mkDefault pkgs.mangowc;
+    package = lib.mkDefault (pkgs.mangowc or pkgs.mango);
     passthru.providedSessions = config.package.passthru.providedSessions;
 
     meta.platforms = lib.platforms.linux;


### PR DESCRIPTION
closes https://github.com/BirdeeHub/nix-wrapper-modules/issues/576